### PR TITLE
[#186622738] use workbench-user-service for fetching namespace

### DIFF
--- a/dnastack/cli/workbench/utils.py
+++ b/dnastack/cli/workbench/utils.py
@@ -4,8 +4,10 @@ from imagination import container
 
 from dnastack.client.workbench.ewes.client import EWesClient
 from dnastack.client.workbench.workflow.client import WorkflowClient
+from dnastack.client.workbench.workbench_user_service.client import WorkbenchUserClient
 from dnastack.cli.config.context import ContextCommandHandler
 from dnastack.cli.helpers.client_factory import ConfigurationBasedClientFactory
+
 
 DEFAULT_WORKBENCH_DESTINATION = "workbench.omics.ai"
 
@@ -15,9 +17,25 @@ def _populate_workbench_endpoint():
     handler.use(DEFAULT_WORKBENCH_DESTINATION, context_name="workbench", no_auth=False)
 
 
+def get_user_client(context_name: Optional[str] = None,
+                        endpoint_id: Optional[str] = None) -> WorkbenchUserClient:
+    factory: ConfigurationBasedClientFactory = container.get(ConfigurationBasedClientFactory)
+    try:
+        return factory.get(WorkbenchUserClient, endpoint_id=endpoint_id, context_name=context_name)
+    except AssertionError:
+        _populate_workbench_endpoint()
+        return factory.get(WorkbenchUserClient, endpoint_id=endpoint_id, context_name=context_name)
+
+
 def get_ewes_client(context_name: Optional[str] = None,
                     endpoint_id: Optional[str] = None,
                     namespace: Optional[str] = None) -> EWesClient:
+    
+
+    if not namespace:
+        user_client = get_user_client(context_name=context_name, endpoint_id=endpoint_id)
+        namespace = user_client.get_user_config().default_namespace
+
     factory: ConfigurationBasedClientFactory = container.get(ConfigurationBasedClientFactory)
     try:
         return factory.get(EWesClient, endpoint_id=endpoint_id, context_name=context_name, namespace=namespace)
@@ -29,12 +47,18 @@ def get_ewes_client(context_name: Optional[str] = None,
 def get_workflow_client(context_name: Optional[str] = None,
                         endpoint_id: Optional[str] = None,
                         namespace: Optional[str] = None) -> WorkflowClient:
+    if not namespace:
+        user_client = get_user_client(context_name=context_name, endpoint_id=endpoint_id)
+        namespace = user_client.get_user_config().default_namespace
+
     factory: ConfigurationBasedClientFactory = container.get(ConfigurationBasedClientFactory)
     try:
         return factory.get(WorkflowClient, endpoint_id=endpoint_id, context_name=context_name, namespace=namespace)
     except AssertionError:
         _populate_workbench_endpoint()
         return factory.get(WorkflowClient, endpoint_id=endpoint_id, context_name=context_name, namespace=namespace)
+
+
 
 
 class UnableToMergeJsonError(RuntimeError):

--- a/dnastack/client/constants.py
+++ b/dnastack/client/constants.py
@@ -1,6 +1,7 @@
 from typing import TypeVar
 
 from dnastack.client.workbench.ewes.client import EWesClient
+from dnastack.client.workbench.workbench_user_service.client import WorkbenchUserClient
 from dnastack.client.workbench.workflow.client import WorkflowClient
 from dnastack.client.base_client import BaseServiceClient
 from dnastack.client.collections.client import CollectionServiceClient
@@ -9,16 +10,17 @@ from dnastack.client.drs import DrsClient
 from dnastack.client.service_registry.client import ServiceRegistry
 
 # All known client classes
-ALL_SERVICE_CLIENT_CLASSES = (CollectionServiceClient, DataConnectClient, DrsClient, ServiceRegistry, EWesClient, WorkflowClient)
+ALL_SERVICE_CLIENT_CLASSES = (CollectionServiceClient, DataConnectClient, DrsClient, ServiceRegistry, EWesClient, WorkflowClient, WorkbenchUserClient)
 
 # All client classes for data access
-DATA_SERVICE_CLIENT_CLASSES = (CollectionServiceClient, DataConnectClient, DrsClient, EWesClient, WorkflowClient)
+DATA_SERVICE_CLIENT_CLASSES = (CollectionServiceClient, DataConnectClient, DrsClient, EWesClient, WorkflowClient, WorkbenchUserClient)
 
 # Type variable for the service client
 SERVICE_CLIENT_CLASS = TypeVar('SERVICE_CLIENT_CLASS',
                                BaseServiceClient,
                                EWesClient,
                                WorkflowClient,
+                               WorkbenchUserClient,
                                CollectionServiceClient,
                                DataConnectClient,
                                DrsClient,

--- a/dnastack/client/workbench/workbench_user_service/client.py
+++ b/dnastack/client/workbench/workbench_user_service/client.py
@@ -7,7 +7,7 @@ from dnastack.client.service_registry.models import ServiceType
 from dnastack.client.workbench.workbench_user_service.models import WorkbenchUser
 
 
-class WusClient(BaseServiceClient):
+class WorkbenchUserClient(BaseServiceClient):
 
     @staticmethod
     def get_adapter_type() -> str:
@@ -27,7 +27,7 @@ class WusClient(BaseServiceClient):
             endpoint.type = cls.get_default_service_type()
         return cls(endpoint)
 
-    def fetch_current_user(self) -> WorkbenchUser:
+    def get_user_config(self) -> WorkbenchUser:
         with self.create_http_session() as session:
             response = session.get(
                 urljoin(self.endpoint.url, f'users/me')


### PR DESCRIPTION
Retrieve user configuration instead of extracting the `sub` from the given token