### PR TITLE
[#86b0hpvwa] Add entrypoint to list of files for creating workflow

### DIFF
--- a/dnastack/cli/workbench/workflows_commands.py
+++ b/dnastack/cli/workbench/workflows_commands.py
@@ -1,7 +1,7 @@
 import binascii
 import os
 from pathlib import Path
-from typing import Optional, List
+from typing import Optional
 
 import click
 from click import style

--- a/dnastack/cli/workbench/workflows_commands.py
+++ b/dnastack/cli/workbench/workflows_commands.py
@@ -1,7 +1,7 @@
 import binascii
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 import click
 from click import style
@@ -278,6 +278,11 @@ def create_workflow(context: Optional[str],
     """
 
     workflows_client = get_workflow_client(context, endpoint_id, namespace)
+    # Add entrypoint to workflow_files
+    if entrypoint not in workflow_files:
+        workflow_files_list = list(workflow_files)
+        workflow_files_list.insert(0, entrypoint)
+        workflow_files = tuple(workflow_files_list)
 
     create_request = WorkflowCreate(
         name=name,

--- a/dnastack/cli/workbench/workflows_commands.py
+++ b/dnastack/cli/workbench/workflows_commands.py
@@ -279,7 +279,12 @@ def create_workflow(context: Optional[str],
 
     workflows_client = get_workflow_client(context, endpoint_id, namespace)
     # Add entrypoint to workflow_files
-    if entrypoint not in workflow_files:
+
+    has_zip = False
+    for file in workflow_files:
+        if file.endswith('.zip'): has_zip = True
+    
+    if not has_zip and os.path.exists(entrypoint) and entrypoint not in workflow_files:
         workflow_files_list = list(workflow_files)
         workflow_files_list.insert(0, entrypoint)
         workflow_files = tuple(workflow_files_list)

--- a/tests/cli/test_workbench.py
+++ b/tests/cli/test_workbench.py
@@ -535,6 +535,13 @@ class TestWorkbenchCommand(WorkbenchCliTestCase):
             self.assertIsNotNone(created_workflow_from_file.internalId, 'Expected custom workflow to be created.')
             self.assertEqual(created_workflow_from_file.source, 'PRIVATE', 'Expected workflow to be PRIVATE.')
 
+            created_workflow_from_file = Workflow(**self.simple_invoke(
+                'workbench', 'workflows', 'create',
+                '--entrypoint', "main.wdl",
+            ))
+            self.assertIsNotNone(created_workflow_from_file.internalId, 'Expected custom workflow to be created.')
+            self.assertEqual(created_workflow_from_file.source, 'PRIVATE', 'Expected workflow to be PRIVATE.')
+
             created_workflow_from_zip = Workflow(**self.simple_invoke(
                 'workbench', 'workflows', 'create',
                 '--entrypoint', "main.wdl",


### PR DESCRIPTION
- Add entrypoint to list of files for creating workflow
- Add test for not including entrypoint in list of files

Note: I noticed that the CLI docs for this command doesn't mention anything about the `--entrypoint` option, so it might be worth updating since `--entrypoint` is a required option