### PR TITLE
Auto-retry HTTP Request #187792925

### DIFF
--- a/dnastack/http/authenticators/oauth2_adapter/device_code_flow.py
+++ b/dnastack/http/authenticators/oauth2_adapter/device_code_flow.py
@@ -11,6 +11,7 @@ from dnastack.common.tracing import Span
 from dnastack.feature_flags import in_global_debug_mode
 from dnastack.http.authenticators.oauth2_adapter.abstract import OAuth2Adapter, AuthException
 from dnastack.http.authenticators.oauth2_adapter.models import OAuth2Authentication
+from dnastack.http.client_factory import HttpClientFactory
 
 
 class DeviceCodeFlowAdapter(OAuth2Adapter):
@@ -32,7 +33,7 @@ class DeviceCodeFlowAdapter(OAuth2Adapter):
         ]
 
     def exchange_tokens(self, trace_context: Span) -> Dict[str, Any]:
-        session = Session()
+        session = HttpClientFactory.make()
 
         auth_info = self._auth_info
         grant_type = auth_info.grant_type

--- a/dnastack/http/client_factory.py
+++ b/dnastack/http/client_factory.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from imagination.decorator.service import Service
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+
+@Service()
+class HttpClientFactory:
+    __DEFAULT_RETRY_OPTION = Retry(total=5,
+                                   backoff_factor=0.5,
+                                   status_forcelist=[500, 502, 503, 504])
+
+    @classmethod
+    def make(cls, retry_option: Optional[Retry] = None) -> Session:
+        s = Session()
+        for prefix in {'http', 'https'}:
+            s.mount(prefix, HTTPAdapter(max_retries=retry_option or cls.__DEFAULT_RETRY_OPTION))
+        return s

--- a/dnastack/http/session.py
+++ b/dnastack/http/session.py
@@ -14,6 +14,7 @@ from dnastack.common.tracing import Span
 from dnastack.constants import __version__
 from dnastack.http.authenticators.abstract import Authenticator
 from dnastack.http.authenticators.oauth2 import OAuth2Authenticator
+from dnastack.http.client_factory import HttpClientFactory
 
 
 class AuthenticationError(RuntimeError):
@@ -128,7 +129,7 @@ class HttpSession(AbstractContextManager):
     @property
     def _session(self) -> Session:
         if not self.__session:
-            self.__session = Session()
+            self.__session = HttpClientFactory.make()
             self.__session.headers.update({
                 'User-Agent': self.generate_http_user_agent()
             })

--- a/dnastack/http/session.py
+++ b/dnastack/http/session.py
@@ -4,6 +4,7 @@ from contextlib import AbstractContextManager
 from typing import List, Optional, Any
 from uuid import uuid4
 
+import jwt
 from pydantic import BaseModel
 from requests import Session, Response
 
@@ -12,6 +13,7 @@ from dnastack.common.logger import get_logger
 from dnastack.common.tracing import Span
 from dnastack.constants import __version__
 from dnastack.http.authenticators.abstract import Authenticator
+from dnastack.http.authenticators.oauth2 import OAuth2Authenticator
 
 
 class AuthenticationError(RuntimeError):
@@ -35,12 +37,16 @@ class HttpError(RuntimeError):
 
         error_feedback = f'HTTP {response.status_code}'
 
-        # Handle the response body.
+        # Prepare the error feedback.
         response_text = response.text.strip()
         if len(response_text) == 0:
             error_feedback = f'{error_feedback} (empty response)'
         else:
             error_feedback = f'{error_feedback}: {response_text}'
+
+        trace: Span = self.trace
+        if trace:
+            error_feedback = f'[{trace.trace_id},{trace.span_id}] {error_feedback}'
 
         return error_feedback
 
@@ -253,11 +259,17 @@ class HttpSession(AbstractContextManager):
                     else:
                         raise RuntimeError('Invalid state')
                 else:
+                    logger.error(f'--x--> HTTP {response.status_code}: {method} {url}')
                     # Non-access-denied error will be handled here.
-                    self._raise_http_error(response, trace_context=trace_context)
+                    self._raise_http_error(response,
+                                           authenticator=authenticator,
+                                           trace_context=trace_context)
             else:
+                logger.error(f'--x--> HTTP {response.status_code}: {method} {url}')
                 # No-auth requests will just throw an exception.
-                self._raise_http_error(response, trace_context=trace_context)
+                self._raise_http_error(response,
+                                       authenticator=authenticator,
+                                       trace_context=trace_context)
         # End if response is not OK.
 
     def get(self, url, trace_context: Optional[Span] = None, **kwargs) -> Response:
@@ -296,7 +308,38 @@ class HttpSession(AbstractContextManager):
     def authenticators(self):
         return self.__authenticators
 
-    def _raise_http_error(self, response: Response, trace_context: Span):
+    def _raise_http_error(self,
+                          response: Response,
+                          authenticator: Authenticator,
+                          trace_context: Span):
+        trace_logger = trace_context.create_span_logger(self.__logger) if trace_context else self.__logger
+
+        if isinstance(authenticator, OAuth2Authenticator):
+            last_known_session_info = authenticator.last_known_session_info
+
+            if last_known_session_info:
+                trace_logger.error(f'session_id = {authenticator.session_id}')
+
+                # noinspection PyBroadException
+                try:
+                    parsed_response = response.json()
+                except Exception:
+                    parsed_response = None
+
+                if isinstance(parsed_response, dict) and parsed_response.get('error') == 'invalid_token':
+                    trace_logger.error(f'The server responded with an invalid token error.')
+                    token = last_known_session_info.access_token
+                    if token:
+                        trace_logger.error(f'The token claims are {jwt.decode(token, options={"verify_signature": False})}.')
+                    else:
+                        trace_logger.error(f'The token is not available for this request.')
+                else:
+                    pass  # No need for additional error handling.
+            else:
+                pass  # As there is no session info, there is no additional info to extract.
+        else:
+            trace_logger.error(f'The authenticator is not available or supported for extracting additional info.')
+
         raise (ClientError if response.status_code < 500 else ServerError)(response, trace_context=trace_context)
 
     def __del__(self):

--- a/tests/alpha/app/test_explorer.py
+++ b/tests/alpha/app/test_explorer.py
@@ -89,7 +89,7 @@ class TestEndToEnd(TestCase):
 
                     df = collection.query(
                         # language=sql
-                        f'SELECT * FROM {table.name}'
+                        f'SELECT * FROM {table.name} LIMIT 10'
                     ).to_data_frame()
 
                     self.assertGreaterEqual(len(df), 0, 'Failed to iterating the result.')

--- a/tests/alpha/app/test_publisher.py
+++ b/tests/alpha/app/test_publisher.py
@@ -89,7 +89,7 @@ class TestEndToEnd(TestCase):
 
                     df = publisher.query(
                         # language=sql
-                        f'SELECT * FROM {table.name}'
+                        f'SELECT * FROM {table.name} LIMIT 10'
                     ).to_data_frame()
 
                     self.assertGreaterEqual(len(df), 0, 'Failed to iterating the result.')

--- a/tests/cli/test_dataconnect.py
+++ b/tests/cli/test_dataconnect.py
@@ -18,11 +18,11 @@ class TestDataConnectCommand(PublisherCliTestCase, DataConnectTestCaseMixin):
         self.invoke('use', self.explorer_urls[0])
 
         if not self.usable_endpoints:
-            self.usable_endpoints.extend([
+            self.usable_endpoints = [
                 ServiceEndpoint(**endpoint)
                 for endpoint in self.simple_invoke('config', 'endpoints', 'list', '-o', 'json')
                 if endpoint['type'] == DATA_CONNECT_TYPE_V1_0
-            ])
+            ]
 
     def _get_default_parameters(self) -> List[str]:
         return ['--endpoint-id', self.usable_endpoints[0].id, '-o', 'json']

--- a/tests/test_http_authenticators_oauth2.py
+++ b/tests/test_http_authenticators_oauth2.py
@@ -1,14 +1,16 @@
+import sys
 from time import time
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
 import jwt
-from requests import Response
+from requests import Response, Session
 
 from dnastack import ServiceEndpoint
 from dnastack.http.authenticators.abstract import ReauthenticationRequired
 from dnastack.http.authenticators.oauth2 import OAuth2Authenticator
 from dnastack.http.authenticators.oauth2_adapter.factory import OAuth2AdapterFactory
+from dnastack.http.client_factory import HttpClientFactory
 from dnastack.http.session_info import SessionManager, SessionInfo, SessionInfoHandler
 
 
@@ -34,19 +36,28 @@ class UnitTest(TestCase):
         with self.assertRaises(ReauthenticationRequired):
             _ = authenticator.refresh()
 
-    def test_handle_expired_refresh_token(self):
-        """ Automatically reset the token when Wallet reports that the refresh token expires (#186428698) """
+    def test_handle_expired_refresh_token_with_token_endpoint(self):
+        """
+        Automatically reset the token when Wallet reports that the refresh token
+        expires WITH the token endpoint defined (#186428698)
+        """
 
         # Set up the test authenticator.
         endpoint = ServiceEndpoint(url='https://dc.faux.dnastack.com')
-        mock_auth_info = dict(grant_type='classified', resource_url=endpoint.url)
+        mock_auth_info = dict(grant_type='classified',
+                              resource_url=endpoint.url,
+                              token_endpoint='https://auth.faux.dnastack.com/oauth/token')
         session_manager = Mock(spec=SessionManager)
         adapter_factory = Mock(spec=OAuth2AdapterFactory)
+        mock_http_session = Mock(spec=Session)
+        http_client_factory = Mock(spec=HttpClientFactory)
+        http_client_factory.make = Mock(return_value=mock_http_session)
 
         authenticator = OAuth2Authenticator(endpoint=endpoint,
                                             auth_info=mock_auth_info,
                                             session_manager=session_manager,
-                                            adapter_factory=adapter_factory)
+                                            adapter_factory=adapter_factory,
+                                            http_client_factory=http_client_factory)
 
         # Set up the test.
         issued_at = time() - 120
@@ -62,8 +73,7 @@ class UnitTest(TestCase):
         session_manager.restore = Mock(return_value=existing_session_info)
 
         # Trigger the action.
-        with self.assertRaises(ReauthenticationRequired):
-            with patch('requests.post') as mock_requests_post:
+        with self.assertRaisesRegex(ReauthenticationRequired, r'Refresh token expired'):
                 token_endpoint_response = Mock(Response)
                 token_endpoint_response.ok = False
                 token_endpoint_response.status_code = 400
@@ -73,6 +83,55 @@ class UnitTest(TestCase):
                                       'a difference of 1997236935 milliseconds.  Allowed clock skew: 0 milliseconds.'
                 )
 
-                mock_requests_post.return_value = token_endpoint_response
+                mock_http_session.post.return_value = token_endpoint_response
 
                 _ = authenticator.refresh()
+
+    def test_handle_expired_refresh_token_without_token_endpoint(self):
+        """
+        Automatically reset the token when Wallet reports that the refresh token
+        expires WITHOUT the token endpoint defined (#186428698)
+        """
+
+        # Set up the test authenticator.
+        endpoint = ServiceEndpoint(url='https://dc.faux.dnastack.com')
+        mock_auth_info = dict(grant_type='classified', resource_url=endpoint.url)
+        session_manager = Mock(spec=SessionManager)
+        adapter_factory = Mock(spec=OAuth2AdapterFactory)
+        mock_http_session = Mock(spec=Session)
+        http_client_factory = Mock(spec=HttpClientFactory)
+        http_client_factory.make = Mock(return_value=mock_http_session)
+
+        authenticator = OAuth2Authenticator(endpoint=endpoint,
+                                            auth_info=mock_auth_info,
+                                            session_manager=session_manager,
+                                            adapter_factory=adapter_factory,
+                                            http_client_factory=http_client_factory)
+
+        # Set up the test.
+        issued_at = time() - 120
+        valid_until = time() - 60
+        refresh_token = jwt.encode(dict(iap=issued_at, exp=valid_until), 'fantasy')
+        existing_session_info = SessionInfo(
+            refresh_token=refresh_token,
+            token_type='mock',
+            issued_at=issued_at,
+            valid_until=valid_until,
+            handler=SessionInfoHandler(auth_info=mock_auth_info),
+        )
+        session_manager.restore = Mock(return_value=existing_session_info)
+
+        # Trigger the action.
+        with self.assertRaisesRegex(ReauthenticationRequired, r'Reauthentication required as the client cannot request for a new token without the token endpoint defined.'):
+            token_endpoint_response = Mock(Response)
+            token_endpoint_response.ok = False
+            token_endpoint_response.status_code = 400
+            token_endpoint_response.headers = {'X-B3-Traceid': 'faux-trace-id'}
+            token_endpoint_response.json.return_value = dict(
+                error_description='JWT expired at 2023-10-15T17:13:22Z. Current time: 2023-11-07T20:00:38Z, '
+                                  'a difference of 1997236935 milliseconds.  Allowed clock skew: 0 milliseconds.'
+            )
+
+            mock_http_session.post.return_value = token_endpoint_response
+
+            _ = authenticator.refresh()


### PR DESCRIPTION
Ticket: [#187792925](https://www.pivotaltracker.com/story/show/187792925)

### What are included in this PR?

* Consolidate the use of `requests`.
  * It is now all going through `dnastack.http.client_factory.HttpClientFactory`.
  * See the migration note below.
* The abstract authenticator (`dnastack.http.authenticators.abstract.Authenticator`) will now keep the last known session info in the memory for debugging.
* The OAuth2 authenticator (`dnastack.http.authenticators.oauth2.OAuth2Authenticator`) will now raise a `ReauthenticationRequired` exception when the authenticator attempts to refresh tokens but the token endpoint is not defined.
* The HTTP wrapper (`dnastack.http.session.HttpSession`) will provide the decoded JWT claims when an error occurs.
* The message from `dnastack.http.session.HttpError` will now include trace information if available.

### Migration Note

For any new HTTP requests or unmigrated code, any direct uses of `requests`, for example,

```python
import requests

requests.get(...)
requests.post(...)
# etc.
```

will now become:

```python
from dnastack.http.client_factory import HttpClientFactory

with HttpClientFactory.make() as session:
  session.get(...)   # Same as `requests.get`
  session.post(...)  # Same as `requests.post`
  # etc.
```

> `HttpClientFactory.make()` returns a pre-configured `requests.Session` with retry options.

> `requests.Session` is closeable but not auto-closeable. **Please either use as a context manager or close the session to ensure that it is closed when it isn't needed.