### PR TITLE
[#187831096] Auth Continuity

### DIFF
--- a/dnastack/cli/helpers/command/decorator.py
+++ b/dnastack/cli/helpers/command/decorator.py
@@ -1,25 +1,20 @@
 ########################################
 # Command and Specification Definition #
 ########################################
-import re
-
+import inspect
 import logging
-
+import re
 import sys
-from click import Group
-
 from traceback import print_exc
-
 from typing import List, Union, Callable, Dict, Any, Optional
 
-import inspect
-
 import click
+from click import Group
 
 from dnastack.cli.helpers.command.spec import ArgumentSpec, SINGLE_ENDPOINT_ID_SPEC
 from dnastack.common.logger import get_logger
 from dnastack.common.tracing import Span
-from dnastack.feature_flags import in_global_debug_mode, show_distributed_trace_stack_on_error
+from dnastack.feature_flags import show_distributed_trace_stack_on_error, currently_in_debug_mode
 
 DEFAULT_SPECS = [
     ArgumentSpec(
@@ -83,7 +78,7 @@ def command(command_group: Group,
         handler_signature = inspect.signature(handler)
 
         def handle_invocation(*args, **kwargs):
-            if in_global_debug_mode:
+            if currently_in_debug_mode():
                 # In the debug mode, no error will be handled gracefully so that the developers can see the full detail.
                 try:
                     handler(*args, **kwargs)

--- a/dnastack/client/base_client.py
+++ b/dnastack/client/base_client.py
@@ -8,7 +8,7 @@ from dnastack.client.models import ServiceEndpoint
 from dnastack.client.service_registry.models import ServiceType
 from dnastack.common.events import EventSource
 from dnastack.common.logger import get_logger
-from dnastack.feature_flags import in_global_debug_mode
+from dnastack.feature_flags import currently_in_debug_mode
 from dnastack.http.authenticators.factory import HttpAuthenticatorFactory
 from dnastack.http.session import HttpSession
 
@@ -23,7 +23,7 @@ class BaseServiceClient(ABC):
         self._uuid = str(uuid4())
         self._endpoint = endpoint
         self._logger = get_logger(f'{type(self).__name__}/{self._endpoint.id}'
-                                  if in_global_debug_mode
+                                  if currently_in_debug_mode()
                                   else type(self).__name__)
         self._current_authenticator: Optional[AuthBase] = None
         self._events = EventSource(['authentication-before',

--- a/dnastack/client/base_exceptions.py
+++ b/dnastack/client/base_exceptions.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional
 
-from dnastack.feature_flags import detailed_error, in_global_debug_mode
+from dnastack.feature_flags import detailed_error, currently_in_debug_mode
 
 
 class AmbiguousArgumentsError(AssertionError):
@@ -90,7 +90,7 @@ class DataConnectError(RuntimeError):
     def __str__(self):
         blocks = [f'HTTP {self.status}: {self.summary}' if self.summary else f'HTTP {self.status}']
 
-        if in_global_debug_mode or detailed_error:
+        if currently_in_debug_mode() or detailed_error:
             if self.details:
                 blocks.append(f'\nResponse Body:\n{self.details}')
 

--- a/dnastack/common/json_argument_parser.py
+++ b/dnastack/common/json_argument_parser.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Union, Tuple
 
 # from dnastack.cli.workbench.utils import UnableToDecodeFileError, UnableToDecodeJSONDataError
 from dnastack.common.logger import get_logger
-from dnastack.feature_flags import in_global_debug_mode
+from dnastack.feature_flags import currently_in_debug_mode
 
 logger = get_logger('json_argument_parser')
 
@@ -17,7 +17,7 @@ try:
 except UnsupportedOperation as e:
     # NOTE This is just to bypass the error raised by Colab's Jupyter Notebook.
     # FIXME Fix the issue where ncurses raises io.UnsupportedOperation.
-    if in_global_debug_mode:
+    if currently_in_debug_mode():
         logger.warning("Could start importing httpie modules but failed to finish it.")
         traceback.print_exc()
         logger.warning(

--- a/dnastack/common/tracing.py
+++ b/dnastack/common/tracing.py
@@ -4,7 +4,7 @@ from abc import ABC
 from typing import Dict, Optional, List, Any, Callable
 
 from dnastack.common.logger import TraceableLogger
-from dnastack.feature_flags import in_global_debug_mode
+from dnastack.feature_flags import currently_in_debug_mode
 
 
 def _generate_random_64bit_string() -> str:
@@ -103,7 +103,7 @@ class _SpanInterface(ABC):
 
         self._logger.debug('End')
 
-        if in_global_debug_mode and not self.parent:
+        if currently_in_debug_mode() and not self.parent:
             self.print_tree(use_logger=True)
 
     def print_tree(self,

--- a/dnastack/configuration/wrapper.py
+++ b/dnastack/configuration/wrapper.py
@@ -1,11 +1,6 @@
 import sys
 from typing import List, Optional
 
-from dnastack import CollectionServiceClient, DataConnectClient, DrsClient
-from dnastack.client.collections.client import EXPLORER_COLLECTION_SERVICE_TYPE_V1_0, \
-    STANDARD_COLLECTION_SERVICE_TYPE_V1_0
-from dnastack.client.data_connect import DATA_CONNECT_TYPE_V1_0
-from dnastack.client.drs import DRS_TYPE_V1_1
 from dnastack.client.models import ServiceEndpoint
 from dnastack.client.service_registry.models import ServiceType
 from dnastack.common.logger import get_logger
@@ -13,7 +8,7 @@ from dnastack.common.simple_stream import SimpleStream
 from dnastack.configuration.exceptions import MissingEndpointError
 from dnastack.configuration.models import Configuration, DEFAULT_CONTEXT
 from dnastack.context.models import Context
-from dnastack.feature_flags import in_global_debug_mode
+from dnastack.feature_flags import currently_in_debug_mode
 
 
 class UnsupportedModelVersionError(RuntimeError):
@@ -109,7 +104,7 @@ class ConfigurationWrapper:
         return endpoint
 
     def __debug_message(self, msg: str):
-        if in_global_debug_mode and 'unittest' in sys.modules:
+        if currently_in_debug_mode() and 'unittest' in sys.modules:
             sys.stderr.write(msg + '\n')
             sys.stderr.flush()
         else:

--- a/dnastack/context/manager.py
+++ b/dnastack/context/manager.py
@@ -272,22 +272,24 @@ class BaseContextManager:
             if exact_url_requested:
                 registry_url = self._check_if_root_url_and_sanitize_url(registry_hostname_or_url)
                 if registry_url:
-                    registry = ServiceRegistry.make(self._create_registry_endpoint_definition(context_name,
-                                                                                              registry_url))
+                    registry = ServiceRegistry.make(
+                        self._create_registry_endpoint_definition(context_name, registry_url)
+                    )
                 else:
                     raise InvalidServiceRegistryError(
-                        f'The given URL ({registry_hostname_or_url}) is not the root URL of the service registry.')
+                        f'The given URL ({registry_hostname_or_url}) is not the root URL of the service registry.'
+                    )
             else:
                 registry = self._scan_for_registry_endpoint(target_hostname)
                 if not registry:
                     raise InvalidServiceRegistryError(
-                        f'The given hostname ({registry_hostname_or_url}) is not a hostname of the service registry service.')
+                        f'The given hostname ({registry_hostname_or_url}) is not a hostname '
+                        'of the service registry service.'
+                    )
 
             context = Context()
             self._contexts.set(context_name, context)
-
             context.endpoints.append(registry.endpoint)
-
             self._contexts.set(context_name, context)
         else:
             pass  # NOOP

--- a/dnastack/feature_flags.py
+++ b/dnastack/feature_flags.py
@@ -1,12 +1,34 @@
 import sys
+from typing import Callable, List, Dict
+
 from dnastack.common.environments import flag
+
+
+__FLAG_CACHE_MAP: Dict[str, bool] = dict()
+__DEBUG_MODE_HOOKS: List[Callable[[bool], None]] = list()
+
+
+def currently_in_debug_mode():
+    previously_enabled = __FLAG_CACHE_MAP.get('debug_mode')
+    currently_enabled = flag('DNASTACK_DEBUG', description='Enable the debug mode')
+
+    if previously_enabled != currently_enabled:
+        __FLAG_CACHE_MAP['debug_mode'] = currently_enabled
+        for hook in __DEBUG_MODE_HOOKS:
+            hook(currently_enabled)
+
+    return currently_enabled
+
+
+def on_debug_mode_change(hook: Callable[[bool], None]):
+    __DEBUG_MODE_HOOKS.append(hook)
+
 
 # For more details about environment variables, please check out dev-configuration.md.
 
 dev_mode = flag('DNASTACK_DEV',
                 description='Make all experimental/work-in-progress functionalities visible')
-in_global_debug_mode = flag('DNASTACK_DEBUG',
-                            description='Enable the debug mode')
+
 in_interactive_shell = sys.__stdout__ and sys.__stdout__.isatty()
 cli_show_list_item_index = flag('DNASTACK_SHOW_LIST_ITEM_INDEX',
                                 description='The CLI output will show the index number of items in any list output')

--- a/dnastack/http/authenticators/abstract.py
+++ b/dnastack/http/authenticators/abstract.py
@@ -8,11 +8,10 @@ from requests import Request, Session
 from requests.auth import AuthBase
 
 from dnastack.client.models import ServiceEndpoint
-from dnastack.common.environments import env
 from dnastack.common.events import EventSource
-from dnastack.common.logger import get_logger, get_logger_for, get_log_level, default_logging_level
+from dnastack.common.logger import get_logger_for
 from dnastack.common.tracing import Span
-from dnastack.http.authenticators.constants import authenticator_log_level
+from dnastack.http.authenticators.constants import get_authenticator_log_level
 from dnastack.http.session_info import SessionInfo
 
 
@@ -114,7 +113,7 @@ class Authenticator(AuthBase, ABC):
                                     'session-not-restored',
                                     'session-revoked'],
                                    origin=self)
-        self._logger = get_logger_for(self, authenticator_log_level)
+        self._logger = get_logger_for(self, get_authenticator_log_level())
 
         # This is for caching and debugging.
         self._last_known_session_info: Optional[SessionInfo] = None

--- a/dnastack/http/authenticators/abstract.py
+++ b/dnastack/http/authenticators/abstract.py
@@ -148,9 +148,10 @@ class Authenticator(AuthBase, ABC):
             logger.debug('initialize: Restoring the session...')
             info = self.restore_session()
             if not info:
-                logger.debug('initialize: Session is not available')
+                logger.debug('initialize: Session is UNAVALIABLE.')
                 raise AuthenticationRequired('Session is not available')
-            elif (not info.access_token or not info.is_valid()):
+            elif not info.is_valid():
+                logger.debug(f'initialize: Session is INVALID ({"expired" if info.access_token else "token revoked"}).')
                 if info.refresh_token:
                     raise RefreshRequired(info)
                 else:

--- a/dnastack/http/authenticators/constants.py
+++ b/dnastack/http/authenticators/constants.py
@@ -3,17 +3,25 @@ import logging
 from dnastack.common.environments import env
 from dnastack.common.logger import get_log_level, default_logging_level
 
-authenticator_log_level_name = env('DNASTACK_AUTH_LOG_LEVEL',
-                                   description='The log level for the authenticator. This overrides '
-                                               'DNASTACK_LOG_LEVEL or the default log level.',
-                                   required=False,
-                                   default=None)
+__DEBUG_LOG_ACTIVATION_NOTIFIED = False
 
-authenticator_log_level = get_log_level(authenticator_log_level_name) \
-    if authenticator_log_level_name \
-    else default_logging_level
 
-if authenticator_log_level == logging.DEBUG:
-    logging.warning('🚨 WARNING: The log level of the authenticator is set to DEBUG. At this level, it may display '
-                    'highly sensitive information, such as an access token, a refresh token, a JWT. You can set the '
-                    'environment variable "DNASTACK_AUTH_LOG_LEVEL" to "INFO", "WARNING", or "ERROR".')
+def get_authenticator_log_level():
+    global __DEBUG_LOG_ACTIVATION_NOTIFIED
+
+    authenticator_log_level_name = env('DNASTACK_AUTH_LOG_LEVEL',
+                                       description='The log level for the authenticator. This overrides '
+                                                   'DNASTACK_LOG_LEVEL or the default log level.',
+                                       required=False,
+                                       default=None)
+
+    authenticator_log_level = get_log_level(authenticator_log_level_name) \
+        if authenticator_log_level_name \
+        else default_logging_level
+
+    if authenticator_log_level == logging.DEBUG and not __DEBUG_LOG_ACTIVATION_NOTIFIED:
+        logging.warning('🚨 WARNING: The log level of the authenticator is set to DEBUG. At this level, it may display '
+                        'highly sensitive information, such as an access token, a refresh token, a JWT. You can set '
+                        'the environment variable "DNASTACK_AUTH_LOG_LEVEL" to "INFO", "WARNING", or "ERROR".')
+
+        __DEBUG_LOG_ACTIVATION_NOTIFIED = True

--- a/dnastack/http/authenticators/oauth2.py
+++ b/dnastack/http/authenticators/oauth2.py
@@ -183,7 +183,21 @@ class OAuth2Authenticator(Authenticator):
                 refresh_token_json['refresh_token'] = refresh_token
 
                 # Update the session
-                self._session_info = self._convert_token_response_to_session(auth_info.dict(), refresh_token_json)
+                updated_session_info = self._convert_token_response_to_session(auth_info.dict(), refresh_token_json)
+                session_info.access_token = updated_session_info.access_token
+                session_info.token_type = updated_session_info.token_type
+                session_info.valid_until = updated_session_info.valid_until
+
+                if updated_session_info.scope:
+                    session_info.scope = updated_session_info.scope
+                
+                if updated_session_info.refresh_token:
+                    # NOTE: The refresh token may not be available in the response.
+                    session_info.refresh_token = updated_session_info.refresh_token
+
+                # "session_info" is already a reference to "self._session_info". This redundant line is here to make it
+                # easier to read the code.
+                self._session_info = session_info
                 self._session_manager.save(session_id, self._session_info)
 
                 event_details['session_info'] = self._session_info

--- a/dnastack/http/authenticators/oauth2.py
+++ b/dnastack/http/authenticators/oauth2.py
@@ -13,7 +13,7 @@ from dnastack.feature_flags import currently_in_debug_mode
 from dnastack.http.authenticators.abstract import Authenticator, AuthenticationRequired, ReauthenticationRequired, \
     RefreshRequired, InvalidStateError, NoRefreshToken, AuthState, ReauthenticationRequiredDueToConfigChange, \
     AuthStateStatus
-from dnastack.http.authenticators.constants import authenticator_log_level
+from dnastack.http.authenticators.constants import get_authenticator_log_level
 from dnastack.http.authenticators.oauth2_adapter.factory import OAuth2AdapterFactory
 from dnastack.http.authenticators.oauth2_adapter.models import OAuth2Authentication
 from dnastack.http.client_factory import HttpClientFactory
@@ -40,7 +40,7 @@ class OAuth2Authenticator(Authenticator):
             if endpoint
             else f'{type(self).__name__}: A/SID:{self.session_id}'
         )
-        self._logger = get_logger(self._logger_name, authenticator_log_level)
+        self._logger = get_logger(self._logger_name, get_authenticator_log_level())
         self._adapter_factory: OAuth2AdapterFactory = adapter_factory or container.get(OAuth2AdapterFactory)
         self._http_client_factory: HttpClientFactory = http_client_factory or container.get(HttpClientFactory)
         self._session_manager: SessionManager = session_manager or container.get(SessionManager)

--- a/dnastack/http/authenticators/oauth2.py
+++ b/dnastack/http/authenticators/oauth2.py
@@ -298,7 +298,7 @@ class OAuth2Authenticator(Authenticator):
 
             raise AuthenticationRequired('No session available')
         elif session.is_valid():
-            logger.debug('The session is valid (based on expiration time).')
+            logger.debug('The session is valid.')
 
             current_auth_info = OAuth2Authentication(**self._auth_info)
             current_config_hash = current_auth_info.get_content_hash()
@@ -316,7 +316,7 @@ class OAuth2Authenticator(Authenticator):
                     'The session is invalidated as the endpoint configuration has changed.'
                 )
         else:
-            logger.debug('The session is INVALID due to expired token (pre-flight check).')
+            logger.debug(f'The session is INVALID ({"expired" if session.access_token else "token revoked"}).')
 
             if session.refresh_token:
                 event_details['reason'] = 'The session is invalid but it can be refreshed.'

--- a/dnastack/http/authenticators/oauth2.py
+++ b/dnastack/http/authenticators/oauth2.py
@@ -251,13 +251,13 @@ class OAuth2Authenticator(Authenticator):
     def clear_access_token(self):
         session_id = self.session_id
 
-        # Clear the local cache
-        self._session_info.access_token = None
-        self._session_manager.save(session_id, self._session_info)
-
-        self._logger.debug(f'Cleared the access token from Session {session_id}')
-
-        self.events.dispatch('session-revoked', dict(session_id=session_id))
+        if self._session_info:
+            # Clear the access token only
+            self._session_info.access_token = None
+            self._session_manager.save(session_id, self._session_info)
+            self._logger.debug(f'Cleared the access token from Session {session_id}')
+        else:
+            pass  # Do nothing
 
     def restore_session(self) -> Optional[SessionInfo]:
         logger = self._logger

--- a/dnastack/http/authenticators/oauth2.py
+++ b/dnastack/http/authenticators/oauth2.py
@@ -9,7 +9,7 @@ from requests import Request, Session, Response
 from dnastack.client.models import ServiceEndpoint
 from dnastack.common.logger import get_logger
 from dnastack.common.tracing import Span
-from dnastack.feature_flags import in_global_debug_mode
+from dnastack.feature_flags import currently_in_debug_mode
 from dnastack.http.authenticators.abstract import Authenticator, AuthenticationRequired, ReauthenticationRequired, \
     RefreshRequired, InvalidStateError, NoRefreshToken, AuthState, ReauthenticationRequiredDueToConfigChange, \
     AuthStateStatus
@@ -223,7 +223,7 @@ class OAuth2Authenticator(Authenticator):
                     self.events.dispatch('refresh-failure', event_details)
 
                 exception_details = {
-                    'debug_mode': in_global_debug_mode,
+                    'debug_mode': currently_in_debug_mode(),
                     'request': {
                         'url': auth_info.token_endpoint,
                     },
@@ -234,7 +234,7 @@ class OAuth2Authenticator(Authenticator):
                     'reason': f'Unable to refresh tokens: {error_msg}',
                 }
 
-                if in_global_debug_mode:
+                if currently_in_debug_mode():
                     exception_details['_internal'] = {
                         'session_info': session_info.dict(),
                         'session_manager': str(self._session_manager),
@@ -358,7 +358,7 @@ class OAuth2Authenticator(Authenticator):
     def update_request(self, session: SessionInfo, r: Union[Request, Session]) -> Union[Request, Session]:
         r.headers["Authorization"] = f"Bearer {session.access_token}"
 
-        if in_global_debug_mode:
+        if currently_in_debug_mode():
             self._logger.debug(f'Bearer Token Claims: {session.access_token.split(".")[1]}')
 
         return r

--- a/dnastack/http/authenticators/oauth2.py
+++ b/dnastack/http/authenticators/oauth2.py
@@ -251,13 +251,15 @@ class OAuth2Authenticator(Authenticator):
     def clear_access_token(self):
         session_id = self.session_id
 
+        self._session_info = self._session_info or self._session_manager.restore(session_id)
+
         if self._session_info:
             # Clear the access token only
             self._session_info.access_token = None
             self._session_manager.save(session_id, self._session_info)
             self._logger.debug(f'Cleared the access token from Session {session_id}')
         else:
-            pass  # Do nothing
+            self._logger.debug(f'Not cleared the access token from Session {session_id} as it is not available')
 
     def restore_session(self) -> Optional[SessionInfo]:
         logger = self._logger
@@ -346,17 +348,6 @@ class OAuth2Authenticator(Authenticator):
             self._logger.debug(f'Bearer Token Claims: {session.access_token.split(".")[1]}')
 
         return r
-
-    def remove_access_token(self):
-        """ Remove the access token """
-        session_id = self.session_id
-
-        session = self._session_manager.restore(session_id)
-        session.access_token = None
-
-        self._session_manager.save(session_id, session)
-
-        self._logger.debug(f'Removed the access token from session {session_id}')
 
     @classmethod
     def make(cls, endpoint: ServiceEndpoint, auth_info: Dict[str, Any]):

--- a/dnastack/http/authenticators/oauth2.py
+++ b/dnastack/http/authenticators/oauth2.py
@@ -57,7 +57,7 @@ class OAuth2Authenticator(Authenticator):
             metadata['C'] = auth_info.client_id
 
             if auth_info.resource_url:
-                metadata['R'] = urlparse(re.split(r'(,| )', auth_info.resource_url)[0]).hostname
+                metadata['R'] = urlparse(re.split(r'(,|\s+)', auth_info.resource_url)[0]).hostname
         elif self._endpoint:
             metadata['E/ID'] = self._endpoint.id
         else:

--- a/dnastack/http/authenticators/oauth2_adapter/device_code_flow.py
+++ b/dnastack/http/authenticators/oauth2_adapter/device_code_flow.py
@@ -1,4 +1,3 @@
-from pprint import pformat
 from time import time, sleep
 from typing import Dict, Any, List
 
@@ -7,7 +6,6 @@ from imagination import container
 from dnastack.common.console import Console
 from dnastack.common.environments import env
 from dnastack.common.tracing import Span
-from dnastack.feature_flags import in_global_debug_mode
 from dnastack.http.authenticators.oauth2_adapter.abstract import OAuth2Adapter, AuthException
 from dnastack.http.authenticators.oauth2_adapter.models import OAuth2Authentication
 from dnastack.http.client_factory import HttpClientFactory

--- a/dnastack/http/session.py
+++ b/dnastack/http/session.py
@@ -13,7 +13,7 @@ from dnastack.common.logger import get_logger
 from dnastack.common.tracing import Span
 from dnastack.constants import __version__
 from dnastack.http.authenticators.abstract import Authenticator
-from dnastack.http.authenticators.constants import authenticator_log_level
+from dnastack.http.authenticators.constants import get_authenticator_log_level
 from dnastack.http.authenticators.oauth2 import OAuth2Authenticator
 from dnastack.http.client_factory import HttpClientFactory
 
@@ -222,7 +222,7 @@ class HttpSession(AbstractContextManager):
             status_code = response.status_code
 
             if self.__enable_auth:
-                fallback_logger = trace_context.create_span_logger(logger, authenticator_log_level)
+                fallback_logger = trace_context.create_span_logger(logger, get_authenticator_log_level())
                 fallback_logger.debug(f'HTTP {status_code}: {method} {url}\n{response.text}')
 
                 if status_code == 401 and authenticator:

--- a/dnastack/http/session.py
+++ b/dnastack/http/session.py
@@ -161,7 +161,7 @@ class HttpSession(AbstractContextManager):
 
         logger = trace_context.create_span_logger(self.__logger)
         params = kwargs.get('params', None)
-        logger.debug(f'{method.upper()} {url} {params} (AUTH: {"Enabled" if self.__enable_auth else "Disabled"})')
+        logger.debug(f'{method.upper()} {url} {params or "(no params)"} (AUTH: {"Enabled" if self.__enable_auth else "Disabled"})')
 
         authenticator: Optional[Authenticator] = None
 
@@ -226,7 +226,7 @@ class HttpSession(AbstractContextManager):
                 fallback_logger.debug(f'HTTP {status_code}: {method} {url}\n{response.text}')
 
                 if status_code == 401 and authenticator:
-                    authenticator.revoke()
+                    authenticator.clear_access_token()
 
                     retry = RetryHistoryEntry(url=url,
                                               authenticator_index=authenticator_index,

--- a/dnastack/http/session_info.py
+++ b/dnastack/http/session_info.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import logging
 import os
 import re
 import shutil
@@ -58,14 +59,18 @@ class SessionInfo(BaseModel):
     valid_until: int  # Epoch timestamp (UTC)
 
     def is_valid(self) -> bool:
-        return time() <= self.valid_until
+        return self.access_token and time() <= self.valid_until
 
     def access_token_claims(self) -> Optional[JwtClaims]:
         return JwtClaims.make(self.access_token) if self.access_token else None
 
 
 # Alias for backward-compatibility with early release candidates
-Session = SessionInfo
+class Session(SessionInfo):
+    def __init__(self, *args, **kwargs):
+        logging.warning('dnastack.http.session_info.Session is deprecated. Please use '
+                        'dnastack.http.session_info.SessionInfo instead.')
+        super().__init__(*args, **kwargs)
 
 
 class UnknownSessionError(RuntimeError):

--- a/docs/dev-configuration.md
+++ b/docs/dev-configuration.md
@@ -6,58 +6,51 @@ This documentation is NOT intended for regular users, such as researchers or dat
 
 These are designed to override configurations specifically related to how the CLI/library operates.
 
-| Variable Name                   | Type   | Usage                                                                                                                                                                                                                                                      | Default Value (if optional)     | 
-|---------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| `DNASTACK_CONFIG_FILE`          | `str`  | Override the default location of the configuration file. For testing, please define this variable.                                                                                                                                                         | `${HOME}/.dnastack/config.yaml` |
-| `DNASTACK_SESSION_DIR`          | `str`  | Override the default location of the session files. For testing, please define this variable.                                                                                                                                                              | `${HOME}/.dnastack/sessions/`   |
-| `DNASTACK_DEBUG`                | `bool` | Enable the global debug mode for the CLI/library. When the debug mode is enabled, the library will override the default log level (`DNASTACK_LOG_LEVEL`) to `DEBUG`. The debug mode of the library/CLI will also enable the debug mode of the HTTP client. | `false`                         |
-| `DNASTACK_LOG_LEVEL`            | `str`  | The default log level. You can choose either `DEBUG`, `INFO`, `WARNING`, or `ERROR`. Please note that setting to `DEBUG` WILL NOT enable the debug mode (`DNASTACK_DEBUG`).                                                                                | `WARNING`                         |
-| `DNASTACK_AUTH_LOG_LEVEL`       | `str`  | The default log level for authenticators. You can choose either `DEBUG`, `INFO`, `WARNING`, or `ERROR`. This will overrides the default log level or the log level defined by `DNASTACK_LOG_LEVEL` or the log level as the result of the debug mode.       | `WARNING`                       |
-| `DNASTACK_SHOW_LIST_ITEM_INDEX` | `bool` | Allow the CLI to show the index number of the list items in the output. This feature is automatically disabled when the CLI runs in the non-interactive shell.                                                                                             | `false`                         |
+### `DNASTACK_AUTH_LOG_LEVEL`       
+| Interpreted Type | Default Value |
+|------------------|---------------|
+| `str`            | `WARNING`     |
 
-## Troubleshooting
+The default log level for authenticators. You can choose either `DEBUG`, `INFO`, `WARNING`, or `ERROR`. This will overrides the default log level or the log level defined by `DNASTACK_LOG_LEVEL` or the log level as the result of the debug mode.       |
 
-#### Configure for an explorer service
+### `DNASTACK_CONFIG_FILE`          
+| Interpreted Type | Default Value                    |
+|------------------|----------------------------------|
+| `str`            | `${HOME}/.dnastack/config .yaml` |
 
-Here is the example.
+Override the default location of the configuration file. For testing, please define this variable.                                                                                                                                                         |
 
-```python
-# Python code
-from dnastack import CollectionServiceClient
-from dnastack.configuration.models import ServiceEndpoint
+### `DNASTACK_DEBUG`                
+| Interpreted Type | Default Value |
+|------------------|---------------|
+| `bool`           | `false`       |
 
-endpoint = ServiceEndpoint(url='https://viral.ai/api/')
-# Alternative: endpoint = ServiceEndpoint(url='https://viral.ai/api/', mode='explorer')
+Enable the global debug mode for the CLI/library. When the debug mode is enabled, the library will override the default log level (`DNASTACK_LOG_LEVEL`) to `DEBUG`. The debug mode of the library/CLI will also enable the debug mode of the HTTP client. |
 
-client = CollectionServiceClient.make(endpoint)
-```
+### `DNASTACK_DEV`                  
+| Interpreted Type | Default Value |
+|------------------|---------------|
+| `bool`           | `false`       |
 
-or
+Display hidden command lines, e.g., low-level commands                                                                                                                                                                                                     |
 
-```bash
-# Shell script
-dnastack config set collections.url https://viral.ai/api/
-# ↓ You don't need this unless you just change the URL to an explorer service, like Viral.ai.
-#dnastack config set collections.mode explorer
-```
+### `DNASTACK_LOG_LEVEL`            
+| Interpreted Type | Default Value |
+|------------------|---------------|
+| `str`            | `WARNING`     |
 
-#### Configure for a collection service
+The default log level. You can choose either `DEBUG`, `INFO`, `WARNING`, or `ERROR`. Please note that setting to `DEBUG` WILL NOT enable the debug mode (`DNASTACK_DEBUG`).                                                                                |
 
-Here is the example.
+### `DNASTACK_SESSION_DIR`          
+| Interpreted Type | Default Value                 |
+|------------------|-------------------------------|
+| `str`            | `${HOME}/.dnastack/sessions/` |
 
-```python
-# Python code
-from dnastack import CollectionServiceClient
-from dnastack.client.models import ServiceEndpoint
+Override the default location of the session files. For testing, please define this variable.                                                                                                                                                              |
 
-endpoint = ServiceEndpoint(url='https://collection-service.red-panda.com', mode='standard')
-client = CollectionServiceClient.make(endpoint)
-```
+### `DNASTACK_SHOW_LIST_ITEM_INDEX` 
+| Interpreted Type | Default Value |
+|------------------|---------------|
+| `bool`           | `false`       |
 
-or
-
-```bash
-# Shell script
-dnastack config set collections.url https://collection-service.red-panda.com
-dnastack config set collections.mode standard
-```
+Allow the CLI to show the index number of the list items in the output. This feature is automatically disabled when the CLI runs in the non-interactive shell.                                                                                             |

--- a/tests/cli/base.py
+++ b/tests/cli/base.py
@@ -13,7 +13,7 @@ from dnastack.__main__ import dnastack as cli_app
 from dnastack.common.logger import get_logger
 from dnastack.configuration.models import Configuration
 from dnastack.context.manager import ContextManager, BaseContextManager
-from dnastack.feature_flags import in_global_debug_mode
+from dnastack.feature_flags import currently_in_debug_mode
 from dnastack.json_path import JsonPath
 from ..exam_helper import BasePublisherTestCase, BaseTestCase
 from ..exam_helper_for_workbench import BaseWorkbenchTestCase
@@ -46,7 +46,7 @@ class CliTestCase(BaseTestCase):
         cls._temporarily_remove_existing_config()
 
     def show_output(self) -> bool:
-        return in_global_debug_mode
+        return currently_in_debug_mode()
 
     def _invoke(self,
                 *cli_blocks: str,

--- a/tests/client/test_stress.py
+++ b/tests/client/test_stress.py
@@ -1,13 +1,12 @@
 import logging
-
 import math
 from unittest import TestCase
 
 from dnastack import CollectionServiceClient
 from dnastack.client.models import ServiceEndpoint
-from dnastack.feature_flags import in_global_debug_mode
 from dnastack.common.environments import flag
 from dnastack.common.logger import get_logger
+from dnastack.feature_flags import currently_in_debug_mode
 
 try:
     import psutil
@@ -17,7 +16,7 @@ except ImportError:
 
 
 class TestStress(TestCase):
-    _logger = get_logger('lib/stress_test', logging.DEBUG if in_global_debug_mode else logging.INFO)
+    _logger = get_logger('lib/stress_test', logging.DEBUG if currently_in_debug_mode() else logging.INFO)
     _proc_info = psutil.Process() if _psutil_installed else None
 
     def setUp(self) -> None:

--- a/tests/exam_helper.py
+++ b/tests/exam_helper.py
@@ -27,9 +27,9 @@ from dnastack.common.environments import env, flag
 from dnastack.common.events import Event
 from dnastack.common.logger import get_logger
 from dnastack.context.manager import BaseContextManager, InMemoryContextManager
-from dnastack.feature_flags import in_global_debug_mode
+from dnastack.feature_flags import currently_in_debug_mode
 from dnastack.http.authenticators.oauth2_adapter.models import OAuth2Authentication
-from tests.cli.auth_utils import handle_device_code_flow, confirm_device_code
+from tests.cli.auth_utils import confirm_device_code
 from tests.wallet_hellper import WalletHelper, Policy, TestUser
 
 _logger = get_logger('exam_helper')
@@ -111,7 +111,7 @@ class BaseTestCase(TestCase):
     _session_dir_path = env(key='DNASTACK_SESSION_DIR', default=f"{default_temp.name}/session.auto_testing")
     _config_file_path = env(key='DNASTACK_CONFIG_FILE', default=f"{default_temp.name}/config.auto_testing.yml")
     _config_overriding_allowed = flag('E2E_CONFIG_OVERRIDING_ALLOWED')
-    _base_logger = get_logger('BaseTestCase', logging.DEBUG if in_global_debug_mode else logging.INFO)
+    _base_logger = get_logger('BaseTestCase', logging.DEBUG if currently_in_debug_mode() else logging.INFO)
     _states: Dict[str, Any] = dict(email=None, token=None)
 
     _user_verification_thread: Optional[Thread] = None
@@ -133,7 +133,7 @@ class BaseTestCase(TestCase):
 
     @staticmethod
     def log_level():
-        return logging.DEBUG if in_global_debug_mode else logging.INFO
+        return logging.DEBUG if currently_in_debug_mode() else logging.INFO
 
     @classmethod
     def set_default_event_interceptors_for_factory(cls, factory: EndpointRepository) -> None:
@@ -225,7 +225,7 @@ class BaseTestCase(TestCase):
     def reset_session(cls):
         if os.path.exists(cls._session_dir_path):
             cls._base_logger.debug("Removing the test session directory...")
-            cls.execute(f'rm -r{"v" if in_global_debug_mode else ""} {cls._session_dir_path}')
+            cls.execute(f'rm -r{"v" if currently_in_debug_mode() else ""} {cls._session_dir_path}')
             cls._base_logger.debug("Removed the test session directory.")
 
     def assert_not_empty(self, obj, message: Optional[str] = None):

--- a/tests/exam_helper.py
+++ b/tests/exam_helper.py
@@ -99,7 +99,9 @@ def assert_equal(expected: Any, given: Any):
     assert expected == given, f'Expected {pformat(expected)}, given {pformat(given)}'
 
 
-def make_mock_response(status_code: int, headers: Optional[Dict] = None, text: Any = None,
+def make_mock_response(status_code: int,
+                       headers: Optional[Dict] = None,
+                       text: Any = None,
                        json_data: Any = None) -> Response:
     mock_response = MagicMock(Response)
     mock_response.headers = headers or dict()

--- a/tests/test_http_session.py
+++ b/tests/test_http_session.py
@@ -16,6 +16,8 @@ from dnastack.http.session_info import InMemorySessionStorage, SessionManager, S
 from requests import Session, Response, Request
 from pydantic import BaseModel, Field
 
+from tests.exam_helper import make_mock_response
+
 
 class HandledRequest(BaseModel):
     path: str
@@ -128,8 +130,8 @@ class TestHttpSession(TestCase):
 
         # ##### Mock response sequence #####
         mock_response_sequence = [
-            self._make_mock_response(401),
-            self._make_mock_response(200),
+            make_mock_response(401),
+            make_mock_response(200),
         ]
 
         def mock_resource_session_get(*args, **kwargs):

--- a/tests/test_http_session.py
+++ b/tests/test_http_session.py
@@ -1,17 +1,19 @@
 import json
 import threading
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from typing import Dict, List
+from time import time, sleep
+from typing import Dict, List, Any, Optional, Union
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock
 
 from dnastack import ServiceEndpoint
+from dnastack.common.tracing import Span
 from dnastack.http.authenticators.abstract import Authenticator, AuthenticationRequired
 from dnastack.http.authenticators.oauth2 import OAuth2Authenticator
 from dnastack.http.authenticators.oauth2_adapter.factory import OAuth2AdapterFactory
 from dnastack.http.session import HttpSession, ClientError
-from dnastack.http.session_info import InMemorySessionStorage, SessionManager
-from requests import Session
+from dnastack.http.session_info import InMemorySessionStorage, SessionManager, SessionInfo
+from requests import Session, Response, Request
 from pydantic import BaseModel, Field
 
 
@@ -80,6 +82,95 @@ class MockWebHandler(BaseHTTPRequestHandler):
 
 
 class TestHttpSession(TestCase):
+
+    def test_handle_midflight_reauthentication(self):
+        mock_session_id = 'foxtrot'
+        mock_session_storage = InMemorySessionStorage()
+        mock_session_manager = SessionManager(mock_session_storage)
+        mock_session_manager.save(mock_session_id, self._make_mock_session_info(ttl=1))
+
+        # ##### Mock the authenticator #####
+        # Please note that this mock setup is a bit complicate as we would like the white-box assertion.
+        class MockAuthenticator(Authenticator):
+            def __init__(self, session_manager: SessionManager, session_id: str):
+                super().__init__()
+                self._session_manager = session_manager
+                self._session_id = session_id
+
+            @property
+            def session_id(self):
+                return self._session_id
+
+            def authenticate(self, trace_context: Span) -> SessionInfo:
+                raise RuntimeError('Unexpected authentication')
+
+            def restore_session(self) -> SessionInfo:
+                return self._session_manager.restore(self._session_id)
+
+            def update_request(self, session: SessionInfo, r: Union[Request, Session]) -> Union[Request, Session]:
+                pass  # Noop
+
+            def revoke(self):
+                self._session_manager.delete(self._session_id)
+
+            def clear_access_token(self):
+                session_id = self.session_id
+
+                session_info = self._session_manager.restore(session_id)
+                session_info.access_token = None
+
+                self._session_manager.save(session_id, session_info)
+
+            def refresh(self, trace_context: Optional[Span] = None) -> SessionInfo:
+                raise RuntimeError('refresh triggered')
+
+        mock_authenticator = MockAuthenticator(mock_session_manager, mock_session_id)
+
+        # ##### Mock response sequence #####
+        mock_response_sequence = [
+            self._make_mock_response(401),
+            self._make_mock_response(200),
+        ]
+
+        def mock_resource_session_get(*args, **kwargs):
+            sleep(1)
+            return mock_response_sequence.pop(0)
+
+        mock_resource_session = MagicMock(Session)
+        mock_resource_session.get.side_effect = mock_resource_session_get
+
+        # ##### Initiate the test #####
+        test_http_session = HttpSession(authenticators=[mock_authenticator], session=mock_resource_session,
+                                        suppress_error=False)
+        # Expected a "not implemented" error.
+        # NOTE: We use this error type as the indicator that the refre
+        with self.assertRaisesRegex(RuntimeError, 'refresh triggered'):
+            test_http_session.get('https://juliet.november')
+
+    def _make_mock_session_info(self, ttl: int) -> SessionInfo:
+        return SessionInfo(access_token='at',
+                           refresh_token='rt',
+                           issued_at=time(),
+                           valid_until=time() + ttl,
+                           token_type='faux')
+
+    def _make_mock_response(self, status_code: int, headers: Optional[Dict] = None, text: Any = None,
+                            json: Any = None) -> Response:
+        mock_response = MagicMock(Response)
+        mock_response.headers = headers or dict()
+        mock_response.status_code = status_code
+        mock_response.ok = 200 <= status_code < 300
+
+        if text:
+            mock_response.text = Mock(return_value=text)
+            mock_response.json = Mock(return_value=json.loads(text))
+        elif json:
+            mock_response.text = Mock(return_value=json.dumps(json))
+            mock_response.json = Mock(return_value=json)
+        else:
+            mock_response.text = ''
+
+        return mock_response
 
     def test_submit_403_status_code(self):
         # Create a mock authenticator


### PR DESCRIPTION
Related Ticket: [#187831096](https://www.pivotaltracker.com/story/show/187831096)

### What's new?

#### Bug Fix: Upon encountering HTTP 401, `HttpSession` now can refresh tokens.

Before this version, `HttpSession` accidentally revoked all token upon receiving HTTP 401. The change here is that the code will only remove the access token and that will force the authenticator to properly refresh tokens.

#### Enable or disable the debug mode at runtime

Previously, the debug mode can only be set when `in_global_debug_mode` is imported for the first time. Now, you can freely enable or disable the debug mode at runtime by simply resetting `DNASTACK_DEBUG` (environment variable, [docs](https://github.com/DNAstack/dnastack-client/blob/main/docs/dev-configuration.md#dnastack_debug)).

```python
import os
os.environ['DNASTACK_DEBUG'] = "true"  # for enabling the debug or "false" otherwise.
```

We also introduce two new functions: `currently_in_debug_mode()` and `on_debug_mode_change()` in `dnastack.feature_flags`.

First, `currently_in_debug_mode()` is to replace the global variable `in_global_debug_mode`. The difference between the function and variable versions is that the function version always checks the feature flag whereas the variable version only checks once when the `dnastack.feature_flags` module is imported.

> **⚠️ BACKWARD INCOMPATIBILITY CHANGE:** All usages of `in_global_debug_mode` (variable) have been replaced with the `currently_in_debug_mode()` and *the variable has been removed in this version*.

The second function, `on_debug_mode_change()`, is a kind of simple event binders where it will register a callback when the debug mode is changed. Here is how to use it.

```python
from dnastack.feature_flags import on_debug_mode_change

def reconfigure_something(in_debug_mode: bool):
    if in_debug_mode:
        # in_debug_mode == True
        ...  # doing something here
    else:
	    # in_debug_mode == False
        ...  # doing something here
```

> **📘 NOTE:** This is still a simple event binding implementation. Please use with caution.

> **📘 NOTE:** Currently, we use this method to reconfigure the default loggers on the fly. However, all logs created via `get_logger()`, `get_logger_for()` and `TraceableLogger.make()` are not automatically bind to the change in the debug mode.
