### PR TITLE
[CU-86b11np6z] fixed DrsObject model to be able to handle empty checksum arrays

### DIFF
--- a/dnastack/client/drs.py
+++ b/dnastack/client/drs.py
@@ -6,7 +6,7 @@ from contextlib import AbstractContextManager
 from datetime import datetime
 from enum import Enum
 from io import TextIOWrapper
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Union
 from urllib.parse import urlparse, urljoin
 
 import urllib3
@@ -141,8 +141,8 @@ class DrsObjectAccessMethod(BaseModel):
 
 
 class DrsObjectChecksum(BaseModel):
-    checksum: str
-    type: str
+    checksum: Optional[str]
+    type: Optional[str]
 
 
 class DrsObject(BaseModel):
@@ -159,6 +159,13 @@ class DrsObject(BaseModel):
     updated_time: datetime
     size: int
     version: Optional[str] = None
+
+    def __init__(self, **kwargs):
+        # There is an issue in the API where a `[null]` value can be returned in place of the checksums list
+        # This is a workaround to remove the `[null]` value
+        kwargs['checksums'] = [checksum for checksum in kwargs.get('checksums', []) if checksum]
+        super().__init__(**kwargs)
+
 
 
 class DownloadOkEvent(Event):

--- a/dnastack/client/drs.py
+++ b/dnastack/client/drs.py
@@ -6,7 +6,7 @@ from contextlib import AbstractContextManager
 from datetime import datetime
 from enum import Enum
 from io import TextIOWrapper
-from typing import Optional, List, Dict, Union
+from typing import Optional, List, Dict
 from urllib.parse import urlparse, urljoin
 
 import urllib3

--- a/tests/client/test_drs.py
+++ b/tests/client/test_drs.py
@@ -1,8 +1,10 @@
 import os
+from datetime import datetime
 from typing import Dict, List, Optional, Any
+from unittest import TestCase
 from urllib.parse import urlparse
 
-from dnastack.client.drs import DrsApiError, Blob, DrsClient
+from dnastack.client.drs import DrsApiError, Blob, DrsClient, DrsObject
 from dnastack.client.factory import EndpointRepository
 from tests.exam_helper import BasePublisherTestCase
 
@@ -133,3 +135,23 @@ class TestDrsClient(BasePublisherTestCase):
                 self.assertEqual(blob_by_id.drs_object, blob_by_url.drs_object)
             except DrsApiError:
                 pass
+
+
+class TestDrsModels(TestCase):
+
+    def test_drs_model_loads_with_nulls_in_checksum(self):
+        args = {
+            "id": "id",
+            "name": "name",
+            "created_time": datetime.now(),
+            "updated_time": datetime.now(),
+            "size": 1,
+        }
+
+        ## Test with no checksum set
+        DrsObject(**args)
+
+        ## Test with checksum set to None
+        args["checksums"] = [None]
+        DrsObject(**args)
+


### PR DESCRIPTION
This is one of two fixes that will be going to help fix the issue being experienced by the KKH team. They are currently unable to download DrsObjects because the checksums are `[null]`. This is a bug in the AWS Storage API and there is a fix that will go out for it shortly, however this fix will ensure rapid access to the objects

As far as I can tell, there is no checksum validation, and the main failure results from the fact that the `[None]` checksum array fails type validation with Pydantic