### PR TITLE
[CU-86b2qc350][CU-86b2m28nw] Storage cmds fixes

### DIFF
--- a/dnastack/cli/workbench/storage_commands.py
+++ b/dnastack/cli/workbench/storage_commands.py
@@ -550,7 +550,7 @@ storage_command_group.add_command(storage_platforms_command_group)
                  arg_names=['--path'],
                  help='The path in the storage account where platform data is located.',
                  as_option=True,
-                 required=True,
+                 required=False,
                  default=None
              ),
          ]
@@ -563,15 +563,6 @@ def add_platform(context: Optional[str],
                  storage_id: str,
                  platform_type: str,
                  path: str):
-    # Validate path format
-    if re.match(r'^s3://', path):
-        click.echo(style("Error: Path must not start with 's3://'", fg='red'), err=True, color=True)
-        exit(1)
-
-    # Prefix path with a forward slash if not already present
-    if path and not path.startswith('/'):
-        path = '/' + path
-
     """Create a new platform"""
     client = get_storage_client(context, endpoint_id, namespace)
     platform = Platform(

--- a/dnastack/client/workbench/storage/client.py
+++ b/dnastack/client/workbench/storage/client.py
@@ -1,6 +1,8 @@
 from typing import List, Optional, Iterator
 from urllib.parse import urljoin
 
+import click
+
 from dnastack import ServiceEndpoint
 from dnastack.client.result_iterator import ResultIterator
 from dnastack.client.service_registry.models import ServiceType
@@ -78,13 +80,14 @@ class StorageClient(BaseWorkbenchClient):
             )
         return StorageAccount(**response.json())
 
-    def update_storage_account(self, storage_account_id: str, storage_account: StorageAccount) -> StorageAccount:
+    def update_storage_account(self, storage_account_id: str, storage_account: StorageAccount, if_match: str) -> StorageAccount:
         """Update a storage account."""
         with self.create_http_session() as session:
-            response = session.put(
-                urljoin(self.endpoint.url, f'{self.namespace}/storage/{storage_account_id}'),
-                json=storage_account.dict()
-            )
+            response = session.submit("PUT",
+                                      urljoin(self.endpoint.url, f'{self.namespace}/storage/{storage_account_id}'),
+                                      json=storage_account.dict(),
+                                      headers={"If-Match": if_match}
+                                      )
         return StorageAccount(**response.json())
 
     # Add method for deleting a storage account

--- a/dnastack/client/workbench/storage/models.py
+++ b/dnastack/client/workbench/storage/models.py
@@ -27,14 +27,14 @@ class PlatformType(str, CaseInsensitiveEnum):
 
 
 class AwsStorageAccountCredentials(BaseModel):
+    type: Literal['AWS_ACCESS_KEY'] = 'AWS_ACCESS_KEY'
     access_key_id: Optional[str]
     secret_access_key: Optional[str]
     region: Optional[str]
-    bucket: Optional[str]
-    type: str = 'AWS_ACCESS_KEY'
 
 
 class GcpStorageAccountCredentials(BaseModel):
+    type: Literal['GCP_SERVICE_ACCOUNT'] = 'GCP_SERVICE_ACCOUNT'
     service_account_json: Optional[str]
     region: Optional[str]
     project_id: Optional[str]
@@ -44,9 +44,11 @@ class StorageAccount(BaseModel):
     id: Optional[str]
     namespace: Optional[str]
     name: Optional[str]
+    etag: Optional[str]
     provider: Optional[Provider]
     created_at: Optional[str]
     last_updated_at: Optional[str]
+    bucket: Optional[str]
     credentials: Optional[Union[AwsStorageAccountCredentials, GcpStorageAccountCredentials]]
 
 

--- a/tests/cli/test_workbench.py
+++ b/tests/cli/test_workbench.py
@@ -624,6 +624,28 @@ class TestWorkbenchCommand(WorkbenchCliTestCase):
         self.assertIsNotNone(created_storage_account.name)
         self.assertEqual(created_storage_account.provider, Provider.aws)
 
+    def test_update_aws_storage_account(self):
+        # Setup test data for adding
+        storage_id = f'test-aws-storage-account-{random.randint(0, 100000)}'
+        storage_account = self._create_storage_account(id=storage_id, provider=Provider.aws)
+
+        # Setup test data for updating
+        name = 'Updated AWS Storage Account'
+
+        # Invoke the update_gcp_storage_account command
+        updated_storage_account = StorageAccount(**self.simple_invoke(
+            'workbench', 'storage', 'update', 'aws',
+            storage_id,
+            '--name', name,
+            '--bucket', env('E2E_AWS_BUCKET', default='s3://dnastack-workbench-sample-service-e2e-test', required=False),
+            '--access-key-id', env('E2E_AWS_ACCESS_KEY_ID', required=True),
+            '--secret-access-key', env('E2E_AWS_SECRET_ACCESS_KEY', required=True),
+            '--region', env('E2E_AWS_REGION', default='ca-central-1'),
+        ))
+
+        self.assertEqual(updated_storage_account.id, storage_account.id)
+        self.assertEqual(updated_storage_account.name, name)
+
     def test_storage_add_gcp(self):
         created_storage_account = self._create_storage_account(provider=Provider.gcp)
         self.assertIsNotNone(created_storage_account.id)

--- a/tests/exam_helper_for_workbench.py
+++ b/tests/exam_helper_for_workbench.py
@@ -406,19 +406,12 @@ class BaseWorkbenchTestCase(WithTestUserTestCase):
         if not id:
             id = f'test-storage-account-{random.randint(0, 100000)}'
 
-        path = env('E2E_AWS_BUCKET', required=False, default='/dnastack-workbench-sample-service-e2e-test')
-
-        # Replace s3:// with /
-        if path.startswith('s3://'):
-            path = path.replace('s3://', '/')
-
         return Platform(**self.simple_invoke(
             'workbench', 'storage', 'platforms', 'add',
             id,
             '--name', 'Test Platform',
             '--storage-id', storage_account.id,
             '--platform', 'PACBIO',
-            '--path', path
         ))
 
     def _get_or_create_platform(self, storage_account: StorageAccount) -> Platform:


### PR DESCRIPTION
- Making storage_id positional instead of flag (this change is per CLI doc)
- Fixing storage account add command for GCP, and AWS
- Fixing storage account update command for GCP
- Adding missing storage account update command for AWS
- Updating tests, and fixing previously broken