### PR TITLE
[CU-86b2tucb6] removed click import breaking cli

### DIFF
--- a/dnastack/client/workbench/storage/client.py
+++ b/dnastack/client/workbench/storage/client.py
@@ -1,8 +1,6 @@
 from typing import List, Optional, Iterator
 from urllib.parse import urljoin
 
-import click
-
 from dnastack import ServiceEndpoint
 from dnastack.client.result_iterator import ResultIterator
 from dnastack.client.service_registry.models import ServiceType


### PR DESCRIPTION
This is an exceptionally weird one. It appears that simply by importing click, it completely broke SOME, but not ALL of the commands 🤷 , I have no explanation for why