### PR TITLE
[CU-86b4000uz] Update help text for datasource argument in items command

### DIFF
--- a/dnastack/cli/commands/publisher/collections/items.py
+++ b/dnastack/cli/commands/publisher/collections/items.py
@@ -76,7 +76,7 @@ def list(collection: str,
         ArgumentSpec(
             name='datasource',
             arg_names=['--datasource'],
-            help='The ID of the data source where the files or folders reside, such as a bucket or storage location.',
+            help='The ID or Name of the data source where the files or folders reside, such as a bucket or storage location.',
             required=True,
         ),
         ArgumentSpec(


### PR DESCRIPTION
Clarify that the datasource argument accepts both ID and Name. This improves usability by providing more accurate guidance to users.