### PR TITLE
[CU-86b4n1vft] Add delete_collection method and cleanup in tests for created collections

### DIFF
--- a/dnastack/client/collections/client.py
+++ b/dnastack/client/collections/client.py
@@ -271,6 +271,22 @@ class CollectionServiceClient(BaseServiceClient):
                            params=params, trace_context=trace)
             return None
 
+    def delete_collection(self,
+                          collection_id: str,
+                          trace: Optional[Span] = None) -> None:
+        """ Delete a collection by ID """
+        trace = trace or Span(origin=self)
+        local_logger = trace.create_span_logger(self._logger)
+        with self.create_http_session() as session:
+            try:
+                delete_url = self._get_single_collection_url(collection_id)
+                session.delete(delete_url, trace_context=trace)
+                return None
+            except ClientError as e:
+                if e.response.status_code == 404:
+                    raise UnknownCollectionError(collection_id, trace) from e
+                raise e
+
     def data_connect_endpoint(self,
                               collection: Union[str, Collection, None] = None,
                               no_auth: bool = False) -> ServiceEndpoint:

--- a/dnastack/client/collections/client.py
+++ b/dnastack/client/collections/client.py
@@ -274,18 +274,12 @@ class CollectionServiceClient(BaseServiceClient):
     def delete_collection(self,
                           collection_id: str,
                           trace: Optional[Span] = None) -> None:
-        """ Delete a collection by ID """
         trace = trace or Span(origin=self)
         local_logger = trace.create_span_logger(self._logger)
         with self.create_http_session() as session:
-            try:
-                delete_url = self._get_single_collection_url(collection_id)
-                session.delete(delete_url, trace_context=trace)
-                return None
-            except ClientError as e:
-                if e.response.status_code == 404:
-                    raise UnknownCollectionError(collection_id, trace) from e
-                raise e
+            delete_url = self._get_single_collection_url(collection_id)
+            session.delete(delete_url, trace_context=trace)
+            return None
 
     def data_connect_endpoint(self,
                               collection: Union[str, Collection, None] = None,

--- a/tests/cli/test_publisher.py
+++ b/tests/cli/test_publisher.py
@@ -31,6 +31,23 @@ class TestPublisherCommand(PublisherCliTestCase):
         self.created_collections = []
         self.collection = self._create_empty_collection()
 
+
+    def tearDown(self) -> None:
+        print("Cleaning up collections...")
+        client = _get_collection_service_client()
+
+        for collection in self.created_collections:
+            print("Deleting collection {}...".format(collection.name))
+
+            try:
+                client.delete_collection(collection_id=collection.id)
+            except Exception as e:
+                print(f"Error deleting collection {collection.slugName}: {str(e)}")
+
+        # Call parent tearDown
+        super().tearDown()
+
+
     def _get_first_collection_with_table(self):
         collections_result = self.simple_invoke(
             'publisher', 'collections', 'list'

--- a/tests/cli/test_publisher.py
+++ b/tests/cli/test_publisher.py
@@ -3,11 +3,10 @@ import unittest
 
 import click
 
-from dnastack.client.collections.model import Collection, CollectionItemListOptions
+from dnastack.cli.commands.publisher.collections.utils import _get_collection_service_client
+from dnastack.client.collections.model import Collection
 from dnastack.common.environments import env
 from tests.cli.base import PublisherCliTestCase
-from dnastack.cli.commands.publisher.collections.utils import _get_collection_service_client
-from dnastack.client.collections.model import DeleteCollectionItemRequest
 
 
 class TestPublisherCommand(PublisherCliTestCase):

--- a/tests/cli/test_publisher.py
+++ b/tests/cli/test_publisher.py
@@ -3,9 +3,11 @@ import unittest
 
 import click
 
-from dnastack.client.collections.model import Collection
+from dnastack.client.collections.model import Collection, CollectionItemListOptions
 from dnastack.common.environments import env
 from tests.cli.base import PublisherCliTestCase
+from dnastack.cli.commands.publisher.collections.utils import _get_collection_service_client
+from dnastack.client.collections.model import DeleteCollectionItemRequest
 
 
 class TestPublisherCommand(PublisherCliTestCase):
@@ -26,6 +28,8 @@ class TestPublisherCommand(PublisherCliTestCase):
         else:
             click.echo(f'Registry {collection_service_registry_id} already exists. Skipping adding it.')
 
+        # Track collections created during tests
+        self.created_collections = []
         self.collection = self._create_empty_collection()
 
     def _get_first_collection_with_table(self):
@@ -40,12 +44,15 @@ class TestPublisherCommand(PublisherCliTestCase):
 
     def _create_empty_collection(self):
         collection_name = f'dnastack-client-col{time.time_ns()}'
-        return Collection(**self.simple_invoke(
+        collection = Collection(**self.simple_invoke(
             'publisher', 'collections', 'create',
             '--name', collection_name,
             '--description', "foo",
             '--slug', collection_name,
         ))
+        # Track the created collection
+        self.created_collections.append(collection)
+        return collection
 
 
     def test_collections_list(self):
@@ -102,6 +109,9 @@ class TestPublisherCommand(PublisherCliTestCase):
             '--slug', collection_name,
         ))
 
+        # Track the created collection
+        self.created_collections.append(created_collection)
+
         self.assertEqual(created_collection.name, collection_name)
         self.assertEqual(created_collection.description, "Cohort of participants with quality of life assessments")
         self.assertEqual(created_collection.slugName, collection_name)
@@ -109,12 +119,15 @@ class TestPublisherCommand(PublisherCliTestCase):
 
     def test_collections_create_with_conflicting_name(self):
         collection_name = f'dnastack-client-col{time.time_ns()}'
-        self.simple_invoke(
+        collection_data = self.simple_invoke(
             'publisher', 'collections', 'create',
             '--name', collection_name,
             '--description', "Cohort of participants with quality of life assessments",
             '--slug', collection_name,
         )
+
+        # Track the created collection
+        self.created_collections.append(Collection(**collection_data))
 
         self.expect_error_from([
             'publisher', 'collections', 'create',
@@ -271,3 +284,18 @@ class TestPublisherCommand(PublisherCliTestCase):
         self.assert_not_empty(tables_result, f'Expected at least one table. Found: {tables_result}')
         for table in tables_result:
             self.assert_not_empty(table['name'], 'Table name should not be empty')
+
+    def tearDown(self) -> None:
+        print("Cleaning up collections...")
+        client = _get_collection_service_client()
+
+        for collection in self.created_collections:
+            print("Deleting collection {}...".format(collection.name))
+
+            try:
+                client.delete_collection(collection_id=collection.id)
+            except Exception as e:
+                print(f"Error deleting collection {collection.slugName}: {str(e)}")
+
+        # Call parent tearDown
+        super().tearDown()


### PR DESCRIPTION
This pull request introduces a new method to delete collections in the `dnastack` client library and enhances the test suite to ensure proper cleanup of test-created collections. The changes improve functionality and maintainability by adding a deletion capability and ensuring no residual data remains after tests.

### New functionality in the `dnastack` client:

* Added `delete_collection` method in `dnastack/client/collections/client.py` to enable deletion of collections by ID. This method handles `404` errors by raising a custom `UnknownCollectionError`.

### Enhancements to the test suite:

* Updated `tests/cli/test_publisher.py` to track collections created during tests using a new `self.created_collections` list.
* Modified `_create_empty_collection` and `test_collections_create` methods to append created collections to `self.created_collections` for tracking. [[1]](diffhunk://#diff-d57cec01d98dec8f6e318f19e0bbd2544a4b281a18f7339ba4ac1887278bead5L43-R55) [[2]](diffhunk://#diff-d57cec01d98dec8f6e318f19e0bbd2544a4b281a18f7339ba4ac1887278bead5R112-R131)
* Added a `tearDown` method to clean up collections created during tests by invoking the new `delete_collection` method. This ensures no residual test data remains.