### PR TITLE
[86b4t9qhb] Fix service type conflict between DataSourceServiceClient and CollectionServiceClient

### DIFF
--- a/dnastack/client/collections/client.py
+++ b/dnastack/client/collections/client.py
@@ -22,7 +22,7 @@ STANDARD_COLLECTION_SERVICE_TYPE_V1_0 = ServiceType(group='com.dnastack',
                                                     artifact='collection-service',
                                                     version='1.0.0')
 STANDARD_DATASOURCE_SERVICE_TYPE_V1_0 = ServiceType(group='com.dnastack',
-                                                    artifact='datasource-service',
+                                                    artifact='collection-service',
                                                     version='1.0.0')
 
 

--- a/dnastack/client/collections/client.py
+++ b/dnastack/client/collections/client.py
@@ -22,7 +22,7 @@ STANDARD_COLLECTION_SERVICE_TYPE_V1_0 = ServiceType(group='com.dnastack',
                                                     artifact='collection-service',
                                                     version='1.0.0')
 STANDARD_DATASOURCE_SERVICE_TYPE_V1_0 = ServiceType(group='com.dnastack',
-                                                    artifact='collection-service',
+                                                    artifact='datasource-service',
                                                     version='1.0.0')
 
 
@@ -33,9 +33,6 @@ EXPLORER_COLLECTION_SERVICE_TYPE_V1_0 = ServiceType(group='com.dnastack.explorer
                                                     version='1.0.0')
 
 
-STANDARD_DATA_SOURCE_SERVICE_TYPE_V1_0 = ServiceType(group='com.dnastack',
-                                                    artifact='collection-service',
-                                                    version='1.0.0')
 
 
 class InvalidApiResponse(RuntimeError):

--- a/dnastack/client/datasources/client.py
+++ b/dnastack/client/datasources/client.py
@@ -97,7 +97,7 @@ class DataSourceServiceClient(BaseServiceClient):
 
     @staticmethod
     def get_adapter_type() -> str:
-        return 'dataousrces'
+        return 'datasources'
 
     @classmethod
     def get_supported_service_types(cls) -> List[str]:


### PR DESCRIPTION
Resolves the "default endpoint not defined" error where DataSourceServiceClient was interfering with collection service's default endpoint mapping, requiring users to explicitly specify --endpoint-id=collection-service.

Changes:
- Fix typo in DataSourceServiceClient.get_adapter_type() from 'dataousrces' to 'datasources'
- Change STANDARD_DATASOURCE_SERVICE_TYPE_V1_0 artifact from 'collection-service' to 'datasource-service'
- Remove duplicate STANDARD_DATA_SOURCE_SERVICE_TYPE_V1_0 definition