### PR TITLE
[CU-86b57mxvh] Add DNAStack Client IntelliJ/Pycharm run configuration

### DIFF
--- a/.run/Omics CLI.run.xml
+++ b/.run/Omics CLI.run.xml
@@ -1,0 +1,35 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Omics CLI" type="PythonConfigurationType" factoryName="Python">
+    <module name="dnastack-client" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <EXTENSION ID="net.ashald.envfile">
+      <option name="IS_ENABLED" value="false" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
+      </ENTRIES>
+    </EXTENSION>
+    <option name="SCRIPT_NAME" value="dnastack.omics_cli" />
+    <option name="PARAMETERS" value="" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="true" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -4,3 +4,31 @@ The command line interface and client library for DNAstack services and GA4GH-co
 * This is a fork from [the old repository](https://github.com/DNAstack/dnastack-client-library).
 * Copyright 2024 DNAstack Corp.
 * All usages are permitted under [Apache 2 License](LICENSE).
+
+### Tips
+To run the client in development mode from the current sources:
+
+1. Direct Python execution:
+```
+   python -m dnastack --help
+   python -m dnastack auth login
+   python -m dnastack collections list
+```
+2. Using the omics entry point:
+```
+   python -m dnastack.omics_cli --help
+```
+3. IntelliJ/PyCharm run configuration:
+   - Run the "Omics CLI" configuration in IntelliJ/PyCharm.
+   - This configuration runs the CLI using `python -m dnastack` to avoid module shadowing issues
+
+### FAQ
+
+**Q: Why do I get a `ModuleNotFoundError: No module named 'http.client'` error when I run the `omics_cli.__main__` function 
+through IntelliJ/PyCharm?**
+
+**A:**  The default run configuration in IntelliJ/PyCharm tries to run the CLI script as a standalone file. 
+This causes Python to add `dnastack/` to `sys.path`. Since there is an `http/` directory inside `dnastack/`, it shadows 
+Python's built-in `http` module. As a result, imports like `import http.client` will fail with a `ModuleNotFoundError`.  
+
+To avoid this, use the `python -m dnastack` command or the provided "Omics CLI" run configuration in IntelliJ/PyCharm.


### PR DESCRIPTION
### Change

This PR adds an IntelliJ run configuration that runs Omics CLI correctly and updates the README with directions.

![image](https://github.com/user-attachments/assets/a2108891-0062-4022-90af-75e14f991668)

### Background

Users trying to run `dnastack/__main__.py` or `dnastack/omics_cli.py` `__main__` function may be greeted with this error

![image](https://github.com/user-attachments/assets/4c89dc84-3090-4b15-819d-b033103ef2b3)

![image](https://github.com/user-attachments/assets/04314517-ed7b-45bf-b90b-ce741581f9cd)


