### PR TITLE
[CU-86b5e8pfj] uv: fix build issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,6 @@ This is the DNAstack client library and CLI, a Python package that provides both
 - `make lint` - Run ruff linter to check code style and errors (zero-tolerance policy - all violations must be fixed)
 - `make lint-fix` - Auto-fix linting issues and format code with ruff
   - Runs `uv run ruff check --fix .` to auto-fix violations where possible
-  - Runs `uv run ruff format .` to format code consistently
 - **Configuration**: Minimal setup in `pyproject.toml` with Python 3.11 target and 120 character line length
 - **CI Integration**: GitHub Actions workflow (`.github/workflows/lint.yml`) uses uv for consistent environment
 - **Version**: Fixed at ruff==0.12.0 in pyproject.toml for consistency across environments

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ lint:
 .PHONY: lint-fix
 lint-fix:
 	uv run ruff check --fix .
-	uv run ruff format .
 
 .PHONY: test-e2e
 test-e2e:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ setup: check-uv
 .PHONY: reset
 reset:
 	rm -rf ~/.dnastack/config.yaml
-	rm ~/.dnastack/sessions/* 2> /dev/null
+	rm -rf ~/.dnastack/sessions/* 2> /dev/null || true
 
 .PHONY: test-setup
 test-setup: check-uv

--- a/docs/how-to-run-e2e-tests.md
+++ b/docs/how-to-run-e2e-tests.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-* Python 3.7 or higher
+* Python 3.11 or higher
 * `chromedriver`
   * On MacOS, you need to ensure that the `chromedriver` command is executable.
 * The test environment variable file
@@ -20,8 +20,9 @@
 2. Update the values in `.env` with your test credentials.
    * You may need access to Wallet APIs to create a client, set grants and access policies.
    * At minimum, you'll need to fill in `E2E_PUBLISHER_AUTH_DEVICE_CODE_TEST_EMAIL` and `E2E_PUBLISHER_AUTH_DEVICE_CODE_TEST_TOKEN`.
-3. Run `pip3 install -r requirements.txt`.
-   * `requirements.txt` contains more requirements than the ones in `setup.cfg` for the build and testing processes.
+3. Run `make setup` to set up the development environment with uv.
+   * This command creates a virtual environment and installs all dependencies from `pyproject.toml`.
+   * Alternatively, run `uv sync --group dev` directly.
 
 ### Set up with Google Secret Manager (For team members with GCloud access)
 
@@ -45,11 +46,9 @@
    * This script will pull the envfile from the secret manager.
    * If you need to manage the shared envfiles, use `test_env_manager.py`. Use `--help` for more information.
 
-4. Run 
-   ```shell
-   pip3 install -r requirements.txt
-   ```
-   * `requirements.txt` contains more requirements than the ones in `setup.cfg` for the build and testing processes.
+4. Run `make setup` to set up the development environment with uv.
+   * This command creates a virtual environment and installs all dependencies from `pyproject.toml`.
+   * Alternatively, run `uv sync --group dev` directly.
 
 ### Note on the test suite
 
@@ -60,23 +59,41 @@ The location of the temp files or directories can be found in [the advanced conf
 
 There are three ways to run the test suite.
 
-### 1. Use `python3 -m unittest` directly.
+### 1. Use `make test-e2e` (Recommended)
 
-1. Set environment variables from `.env`.
-   * For example: `source .env` 
-2. Run `python3 -m unittest discover -v -s .` to run all tests.
-   * Alternatively, run `python3 -m unittest -v <FILE_PATH_OR_PYTHON_MODULE>` to run specific tests.
-     * Example 1: `python3 -m unittest -v tests.cli.test_dataconnect`
-     * Example 2: `python3 -m unittest -v tests/cli/test_dataconnect.py`
-   * You can use `-f` to end the test on the first failure.
-   * See [the official docs](https://docs.python.org/3/library/unittest.html) for more information.
+Simply run:
+```bash
+make test-e2e
+```
 
-### Use `./scripts/run-e2e-tests.sh`
+This command automatically:
+- Uses the `.env` file for configuration
+- Runs the test suite through `./scripts/run-e2e-tests.sh`
+- Handles all environment setup automatically
 
-The script is used by the CI/CD pipeline and will work with `.env` right out of the box. It is technically the shortcut
-of [the first method](#1-use-python3--m-unittest-directly)
+### 2. Use `uv run` directly
 
-### Run with IntelliJ or PyCharm
+1. Set environment variables from `.env`:
+   ```bash
+   source .env
+   ```
+2. Run tests using uv:
+   ```bash
+   uv run python -m unittest discover -v -s .
+   ```
+   * To run specific tests:
+     * Example 1: `uv run python -m unittest -v tests.cli.test_dataconnect`
+     * Example 2: `uv run python -m unittest -v tests/cli/test_dataconnect.py`
+   * Use `-f` to end the test on the first failure.
+
+### 3. Use `./scripts/run-e2e-tests.sh` directly
+
+The script is used by the CI/CD pipeline and will work with `.env` right out of the box:
+```bash
+E2E_ENV_FILE=.env ./scripts/run-e2e-tests.sh
+```
+
+### 4. Run with IntelliJ or PyCharm
 
 1. Add a new **Configuration** for **Python tests → Unittests**.
 2. Set target to the root of your working copy, e.g., `/Users/jnopporn/workspace/dnastack-client-library`.

--- a/scripts/build-package.py
+++ b/scripts/build-package.py
@@ -8,7 +8,6 @@ import logging
 import re
 import subprocess
 from argparse import ArgumentParser
-from configparser import ConfigParser
 
 logging.basicConfig(format='%(levelname)s: %(message)s',
                     level=logging.INFO)

--- a/scripts/build-package.py
+++ b/scripts/build-package.py
@@ -95,21 +95,19 @@ def main():
         with open('dnastack/constants.py', 'w') as f:
             f.write(content)
 
-    # Update setup.cfg
-    setup_file_path = 'setup.cfg'
-    setup_config = ConfigParser()
-    setup_config.read(setup_file_path)
-    setup_config['metadata']['version'] = release_version
+    # Update pyproject.toml
+    pyproject_file_path = 'pyproject.toml'
+    with open(pyproject_file_path, 'r') as f:
+        pyproject_content = f.read()
+    
+    # Replace the version in pyproject.toml
+    pyproject_content = re.sub(r'(version\s*=\s*")[^"]+(")', fr'\g<1>{release_version}\g<2>', pyproject_content)
+    
     if in_dry_run_mode:
-        setup_temp_file = 'setup_dryrun.cfg'
-        with open(setup_temp_file, 'w') as f:
-            setup_config.write(f)
-        with open(setup_temp_file, 'r') as f:
-            log.info(f'setup.cfg:\n\n{f.read()}')
-        os.unlink(setup_temp_file)
+        log.info(f'pyproject.toml (version section):\n\nversion = "{release_version}"')
     else:
-        with open(setup_file_path, 'w') as f:
-            setup_config.write(f)
+        with open(pyproject_file_path, 'w') as f:
+            f.write(pyproject_content)
 
     # Build the package
     if args.dry_run:
@@ -120,7 +118,7 @@ def main():
 
     log.info('Cleaning up...')
 
-    subprocess.call(['git', 'checkout', '--', 'setup.cfg', 'dnastack/constants.py'])
+    subprocess.call(['git', 'checkout', '--', 'pyproject.toml', 'dnastack/constants.py'])
 
     log.info('Done')
 


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md documentation to reflect the change
- Removed `ruff format` from the `lint-fix` Makefile target
  - Preserves auto-fix functionality while avoiding excessive formatting changes
- Fixed `scripts/build-package.py` to use `pyproject.toml` instead of deprecated `setup.cfg`
  - CBW builds are failing
  - Updated build script to handle version updates in the new project configuration format

## Changes
1. **Makefile**: Removed `uv run ruff format .` from the `lint-fix` target
2. **CLAUDE.md**: Updated documentation to reflect that `lint-fix` no longer includes formatting
3. **scripts/build-package.py**: 
   - Replaced ConfigParser logic with regex-based replacement for `pyproject.toml`
   - Updated cleanup step to revert `pyproject.toml` instead of `setup.cfg`
   - Fixes KeyError when trying to access 'metadata' section in minimal `setup.cfg`

## Test plan
- [x] Run `make lint-fix` to verify it only runs `ruff check --fix`
- [x] Ensure linting auto-fixes still work correctly
- [x] Test build script with `./scripts/build-package.py --dry-run`
- [x] Verify package builds successfully with `./scripts/build-package.py`
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.ai/code)