### PR TITLE
[CU-86b5e8pfj] Fix CLI test output parsing by separating stderr from stdout

### DIFF
--- a/tests/cli/base.py
+++ b/tests/cli/base.py
@@ -21,7 +21,7 @@ from tests.exam_helper_for_workbench import BaseWorkbenchTestCase
 
 
 class CliTestCase(BaseTestCase):
-    _runner = CliRunner()
+    _runner = CliRunner(mix_stderr=False)
 
     @classmethod
     def get_context_manager(cls) -> BaseContextManager:


### PR DESCRIPTION
## Summary
- Fixed CLI test failures caused by mixed stderr/stdout in test output
- Set `mix_stderr=False` in CliRunner to keep streams separate
- Resolves JSON/YAML parsing errors in test_general_flow

## Problem
The CLI outputs informational messages to stderr (e.g., "Retrieving upto 10 item...") while sending JSON/YAML data to stdout. When the test runner mixed these streams together, the JSON/YAML parser failed with errors like:
```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
yaml.scanner.ScannerError: mapping values are not allowed here
```

## Solution
Configure the Click test runner to keep stderr and stdout separate by setting `mix_stderr=False`.

## Test plan
- [x] Verify the failing test now passes locally
- [ ] Confirm CI tests pass with this change
- [ ] Ensure other CLI tests continue to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)