### PR TITLE
[CU-86b5ftnr2] Updated contract changes to the Sample object in the workbench tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ publish: check-uv
 	@echo "  uv publish --index-url https://test.pypi.org/legacy/"
 
 .PHONY: docker-test-all
-docker-test-all: docker-test-all-python-oldest-stable docker-test-all-python-latest-stable docker-test-all-python-rc
+docker-test-all: docker-test-all-baseline docker-test-all-stable docker-test-all-latest docker-test-all-anaconda docker-test-all-pypy
 
 # Testing the oldest stable version.
 .PHONY: docker-test-all-baseline

--- a/dnastack/client/workbench/samples/models.py
+++ b/dnastack/client/workbench/samples/models.py
@@ -26,7 +26,6 @@ class Sample(BaseModel):
     id: str
     created_at: Optional[datetime]
     last_updated_at: Optional[datetime]
-    files: Optional[List[SampleFile]]
 
 
 class SampleListResponse(PaginatedResource):

--- a/docs/how-to-run-e2e-tests.md
+++ b/docs/how-to-run-e2e-tests.md
@@ -71,11 +71,31 @@ This command automatically:
 - Runs the test suite through `./scripts/run-e2e-tests.sh`
 - Handles all environment setup automatically
 
-### 2. Use `uv run` directly
+### 2. Use `./scripts/run-e2e-tests.sh` directly (Recommended for single tests)
 
-1. Set environment variables from `.env`:
+The script is used by the CI/CD pipeline and provides the most reliable test execution:
+```bash
+E2E_ENV_FILE=.env ./scripts/run-e2e-tests.sh
+```
+
+For specific tests:
+```bash
+E2E_ENV_FILE=.env ./scripts/run-e2e-tests.sh -v tests.cli.test_workbench.TestWorkbenchCommand.test_samples_list_and_describe
+```
+
+The script automatically handles:
+- Loading environment variables from the specified file
+- Cleaning up stale session data (critical for authentication)
+- Installing required dependencies (selenium)
+- Proper test runner initialization
+
+### 3. Use `uv run` directly (Manual approach)
+
+**Note:** This approach requires manual session cleanup and may encounter authentication issues if session data is stale.
+
+1. Set environment variables and clean sessions:
    ```bash
-   source .env
+   set -a && source .env && set +a && rm -rf ~/.dnastack/sessions/*
    ```
 2. Run tests using uv:
    ```bash
@@ -86,12 +106,7 @@ This command automatically:
      * Example 2: `uv run python -m unittest -v tests/cli/test_dataconnect.py`
    * Use `-f` to end the test on the first failure.
 
-### 3. Use `./scripts/run-e2e-tests.sh` directly
-
-The script is used by the CI/CD pipeline and will work with `.env` right out of the box:
-```bash
-E2E_ENV_FILE=.env ./scripts/run-e2e-tests.sh
-```
+**Why session cleanup is important:** The DNAstack client caches authentication sessions. Stale sessions can cause authentication failures, especially when switching between different test environments or after authentication token expiration.
 
 ### 4. Run with IntelliJ or PyCharm
 

--- a/tests/cli/test_workbench.py
+++ b/tests/cli/test_workbench.py
@@ -586,27 +586,6 @@ class TestWorkbenchCommand(WorkbenchCliTestCase):
             'workbench', 'samples', 'describe', samples[0].id
         ))
         self.assertEqual(sample.id, samples[0].id)
-        self.assert_not_empty(sample.files, 'Sample files should not be empty')
-        self.assert_not_empty(sample.files[0].path, 'Sample file path should not be empty')
-
-    def _wait_for_samples(self):
-        timeout = 300
-        start_time = asyncio.get_event_loop().time()
-        while True:
-            samples = [Sample(**sample) for sample in self.simple_invoke(
-                'workbench', 'samples', 'list'
-            )]
-            if samples:
-                break
-            if asyncio.get_event_loop().time() - start_time > timeout:
-                raise TimeoutError("Timeout reached while waiting for samples to be created.")
-            sleep(2)
-        return samples
-
-    def _wait(self):
-        timeout = 30
-        asyncio.get_event_loop().time()
-        sleep(timeout)
 
     def test_samples_files_list(self):
         self._create_storage_account(provider=Provider.aws)
@@ -1505,3 +1484,23 @@ class TestWorkbenchCommand(WorkbenchCliTestCase):
         self.assert_not_empty(instruments, f'Expected at least one instrument. Found {instruments}')
         for instrument in instruments:
             self.assert_not_empty(instrument.id, 'Instrument ID should not be empty')
+
+
+    def _wait_for_samples(self):
+        timeout = 300
+        start_time = asyncio.get_event_loop().time()
+        while True:
+            samples = [Sample(**sample) for sample in self.simple_invoke(
+                'workbench', 'samples', 'list'
+            )]
+            if samples:
+                break
+            if asyncio.get_event_loop().time() - start_time > timeout:
+                raise TimeoutError("Timeout reached while waiting for samples to be created.")
+            sleep(2)
+        return samples
+
+    def _wait(self):
+        timeout = 30
+        asyncio.get_event_loop().time()
+        sleep(timeout)

--- a/tests/cli/test_workbench.py
+++ b/tests/cli/test_workbench.py
@@ -606,7 +606,15 @@ class TestWorkbenchCommand(WorkbenchCliTestCase):
         self.assert_not_empty(sample_files, f'Expected at least one sample file. Found {sample_files}')
         self.assertTrue(all(sample_file.sample_id == sample.id for sample_file in sample_files))
 
-        ## Add another test case where we pass the platform id
+    def test_samples_files_list_with_platform_type(self):
+        self._create_storage_account(provider=Provider.aws)
+        samples = self._wait_for_samples()
+        self._wait()
+        self.assert_not_empty(samples, f'Expected at least one sample. Found {samples}')
+        for sample in samples:
+            self.assert_not_empty(sample.id, 'Sample ID should not be empty')
+        sample = samples[0]
+
         sample_files = [SampleFile(**sample_file) for sample_file in self.simple_invoke(
             'workbench', 'samples', 'files', 'list',
             '--sample', sample.id,

--- a/tests/exam_helper_for_workbench.py
+++ b/tests/exam_helper_for_workbench.py
@@ -386,7 +386,7 @@ class BaseWorkbenchTestCase(WithTestUserTestCase):
     def _create_storage_account(self, provider: Provider, id=None) -> StorageAccount:
         if not id:
             id = f'test-storage-account-{random.randint(0, 100000)}'
-
+        print("Using storage account: ", id)
         if provider == provider.aws:
             return StorageAccount(**self.simple_invoke(
                 'workbench', 'storage', 'add', 'aws',


### PR DESCRIPTION
The field `files` in `Sample` had been optional but a test was still asserting on it's presence. The test broke when the field had been removed in the sample-service and was not sending an empty list anymore. This PR removes the assertions of the optional field.