### PR TITLE
[CU-86b5pq0rk] Fix HttpError initialization bug and enhance error

### DIFF
--- a/dnastack/client/explorer/client.py
+++ b/dnastack/client/explorer/client.py
@@ -91,10 +91,8 @@ class ExplorerClient(BaseServiceClient):
                         f"Not authorized to access question '{question_id}'"
                     )
                 elif status_code == 404:
-                    # Re-raise with original response object and custom message
                     raise ClientError(e.response, e.trace, f"Question '{question_id}' not found")
                 else:
-                    # Re-raise with original response object and custom message
                     raise ClientError(e.response, e.trace, f"Failed to retrieve question '{question_id}'")
 
     def ask_federated_question(
@@ -179,7 +177,7 @@ class FederatedQuestionListResultLoader(ResultLoader):
                         "Not authorized to list federated questions"
                     )
                 else:
-                    # Re-raise with original response object and custom message
+                    
                     raise ClientError(e.response, e.trace, "Failed to load federated questions")
 
 
@@ -246,8 +244,8 @@ class FederatedQuestionQueryResultLoader(ResultLoader):
                         "Not authorized to ask federated questions"
                     )
                 elif status_code == 400:
-                    # Re-raise with original response object and custom message
+                    
                     raise ClientError(e.response, e.trace, "Invalid question parameters")
                 else:
-                    # Re-raise with original response object and custom message
+                    
                     raise ClientError(e.response, e.trace, "Failed to execute federated question")

--- a/dnastack/client/explorer/client.py
+++ b/dnastack/client/explorer/client.py
@@ -91,11 +91,11 @@ class ExplorerClient(BaseServiceClient):
                         f"Not authorized to access question '{question_id}'"
                     )
                 elif status_code == 404:
-                    raise ClientError(f"Question '{question_id}' not found")
+                    # Re-raise with original response object and custom message
+                    raise ClientError(e.response, e.trace, f"Question '{question_id}' not found")
                 else:
-                    raise ClientError(
-                        f"Failed to retrieve question '{question_id}': {e.response.text}"
-                    )
+                    # Re-raise with original response object and custom message
+                    raise ClientError(e.response, e.trace, f"Failed to retrieve question '{question_id}'")
 
     def ask_federated_question(
         self,
@@ -179,9 +179,8 @@ class FederatedQuestionListResultLoader(ResultLoader):
                         "Not authorized to list federated questions"
                     )
                 else:
-                    raise ClientError(
-                        f"Failed to load federated questions: {e.response.text}"
-                    )
+                    # Re-raise with original response object and custom message
+                    raise ClientError(e.response, e.trace, "Failed to load federated questions")
 
 
 class FederatedQuestionQueryResultLoader(ResultLoader):
@@ -247,10 +246,8 @@ class FederatedQuestionQueryResultLoader(ResultLoader):
                         "Not authorized to ask federated questions"
                     )
                 elif status_code == 400:
-                    raise ClientError(
-                        f"Invalid question parameters: {e.response.text}"
-                    )
+                    # Re-raise with original response object and custom message
+                    raise ClientError(e.response, e.trace, "Invalid question parameters")
                 else:
-                    raise ClientError(
-                        f"Failed to execute federated question: {e.response.text}"
-                    )
+                    # Re-raise with original response object and custom message
+                    raise ClientError(e.response, e.trace, "Failed to execute federated question")

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import Mock
+from requests import Response
+
+from dnastack.http.session import HttpError, ClientError
+from dnastack.common.tracing import Span
+
+
+class TestSession(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_response = Mock(spec=Response)
+        self.mock_response.status_code = 404
+        self.mock_response.text = "Not Found"
+        
+        # Create a mock trace
+        self.mock_trace = Mock(spec=Span)
+        self.mock_trace.trace_id = "test-trace-id"
+        self.mock_trace.span_id = "test-span-id"
+
+    def test_http_error_with_response_only(self):
+        error = HttpError(self.mock_response)
+        
+        self.assertEqual(error.response, self.mock_response)
+        self.assertIsNone(error.trace)
+        self.assertIsNone(error.message)
+        
+        error_str = str(error)
+        self.assertIn("HTTP 404", error_str)
+        self.assertIn("Not Found", error_str)
+        self.assertNotIn("test-trace-id", error_str)
+
+    def test_http_error_with_trace(self):
+        error = HttpError(self.mock_response, self.mock_trace)
+        
+        self.assertEqual(error.response, self.mock_response)
+        self.assertEqual(error.trace, self.mock_trace)
+        self.assertIsNone(error.message)
+        
+        error_str = str(error)
+        self.assertIn("HTTP 404", error_str)
+        self.assertIn("Not Found", error_str)
+        self.assertIn("[test-trace-id,test-span-id]", error_str)
+
+    def test_http_error_with_custom_message(self):
+        custom_message = "Question 'test-question' not found"
+        error = HttpError(self.mock_response, self.mock_trace, custom_message)
+        
+        self.assertEqual(error.response, self.mock_response)
+        self.assertEqual(error.trace, self.mock_trace)
+        self.assertEqual(error.message, custom_message)
+        
+        error_str = str(error)
+        self.assertIn(custom_message, error_str)
+        self.assertIn("HTTP 404", error_str)
+        self.assertIn("Not Found", error_str)
+        self.assertIn("[test-trace-id,test-span-id]", error_str)
+        self.assertIn("Question 'test-question' not found - HTTP 404", error_str)
+
+    def test_http_error_empty_response_text(self):
+        self.mock_response.text = "   "  # Whitespace only
+        error = HttpError(self.mock_response, self.mock_trace)
+        
+        error_str = str(error)
+        self.assertIn("HTTP 404", error_str)
+        self.assertIn("(empty response)", error_str)
+
+    def test_client_error_inherits_properly(self):
+        error = ClientError(self.mock_response, self.mock_trace, "Client error message")
+        
+        self.assertIsInstance(error, HttpError)
+        self.assertIsInstance(error, ClientError)
+        
+        self.assertEqual(error.response, self.mock_response)
+        self.assertEqual(error.trace, self.mock_trace)
+        self.assertEqual(error.message, "Client error message")
+        
+        error_str = str(error)
+        self.assertIn("Client error message", error_str)
+        self.assertIn("HTTP 404", error_str)
+        self.assertIn("Client error message - HTTP 404", error_str)
+
+    def test_backwards_compatibility_without_message(self):
+        error = ClientError(self.mock_response, self.mock_trace)
+        
+        error_str = str(error)
+        self.assertIn("HTTP 404", error_str)
+        self.assertIn("Not Found", error_str)
+        self.assertNotIn(" - HTTP", error_str)  # The dash separator shouldn't be there
+
+    def test_error_args_access(self):
+        error = HttpError(self.mock_response, self.mock_trace, "Custom message")
+        
+        self.assertEqual(len(error.args), 3)
+        self.assertEqual(error.args[0], self.mock_response)
+        self.assertEqual(error.args[1], self.mock_trace)
+        self.assertEqual(error.args[2], "Custom message")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
messaging

Fixed AttributeError in HttpError.__str__ method that occurred when ClientError was initialized with string messages instead of Response objects. The bug manifested when explorer client error handling tried to access response.status_code on a string object.