### PR TITLE
[CU-86b5pq0rk] Remove redundant API call

### DIFF
--- a/dnastack/cli/commands/explorer/questions/commands.py
+++ b/dnastack/cli/commands/explorer/questions/commands.py
@@ -152,6 +152,8 @@ def init_questions_commands(group: Group):
             if invalid_ids:
                 click.echo(f"Error: Invalid collection IDs for this question: {', '.join(invalid_ids)}", err=True)
                 raise click.Abort()
+        else:
+            collection_ids = [col.id for col in question.collections]
         
         # Execute the question
         results_iter = client.ask_federated_question(


### PR DESCRIPTION
  • use collection IDs from already-fetched question object when not specified by user
  • Prevents client from making duplicate GET /api/questions/{id} request to reduce API calls
[CU-86b5pq0rk]