### PR TITLE
[CU-86b63wew7] Add RunEvent information to events

### DIFF
--- a/tests/e2e_tests/client/test_ewes.py
+++ b/tests/e2e_tests/client/test_ewes.py
@@ -56,3 +56,64 @@ class TestClient(BaseWorkbenchTestCase):
         runs = list(ewes_client.list_runs(list_options=ExtendedRunListOptions(engine_id='foo'),
                                           max_results=None))
         self.assertEqual(len(runs), 0, 'Expected exactly zero runs.')
+
+    def test_list_run_events(self):
+        """Test listing run events and verifying discriminated union deserialization."""
+        ewes_client: EWesClient = self.get_ewes_client()
+        submitted_run = self.submit_hello_world_workflow_run()
+
+        # Test list_events method
+        run_events = ewes_client.list_events(submitted_run.run_id)
+        self.assertIsNotNone(run_events, 'Expected ExtendedRunEvents object')
+        self.assertIsNotNone(run_events.events, 'Expected events list to be present')
+        self.assertGreater(len(run_events.events), 0, 'Expected at least one event')
+
+        # Test first event (should be RUN_SUBMITTED)
+        first_event = run_events.events[0]
+        from dnastack.client.workbench.ewes.models import EventType, RunSubmittedMetadata
+        
+        self.assertEqual(first_event.event_type, EventType.RUN_SUBMITTED,
+                         'Expected first event to be RUN_SUBMITTED')
+        
+        # Test discriminated union deserialization
+        self.assertIsInstance(first_event.metadata, RunSubmittedMetadata,
+                              'Expected RunSubmittedMetadata for RUN_SUBMITTED event')
+        
+        # Test discriminator field consistency
+        self.assertEqual(first_event.event_type, first_event.metadata.event_type,
+                         'Expected event_type to match between event and metadata')
+
+        # Test that metadata fields are properly typed and accessible
+        self.assertIsNotNone(first_event.id, 'Expected event to have ID')
+        self.assertIsNotNone(first_event.created_at, 'Expected event to have created_at timestamp')
+        
+        # Test optional fields behavior
+        submitted_by = first_event.metadata.submitted_by
+        workflow_name = first_event.metadata.workflow_name
+        
+        # These might be None depending on the actual event data
+        # Just verify they're accessible without AttributeError
+        self.assertTrue(submitted_by is None or isinstance(submitted_by, str),
+                        'submitted_by should be None or string')
+        self.assertTrue(workflow_name is None or isinstance(workflow_name, str),
+                        'workflow_name should be None or string')
+
+        # Test serialization roundtrip for all events
+        for i, event in enumerate(run_events.events):
+            try:
+                # Convert to dict and back
+                event_dict = event.dict()
+                from dnastack.client.workbench.ewes.models import RunEvent
+                reconstructed_event = RunEvent(**event_dict)
+                
+                self.assertEqual(event.id, reconstructed_event.id,
+                                 f'Event {i}: ID mismatch after serialization roundtrip')
+                self.assertEqual(event.event_type, reconstructed_event.event_type,
+                                 f'Event {i}: event_type mismatch after serialization roundtrip')
+                self.assertEqual(type(event.metadata), type(reconstructed_event.metadata),
+                                 f'Event {i}: metadata type mismatch after serialization roundtrip')
+                
+            except Exception as e:
+                self.fail(f'Serialization roundtrip failed for event {i}: {e}')
+
+        print(f'Successfully tested {len(run_events.events)} events for run {submitted_run.run_id}')

--- a/tests/unit/client/workbench/__init__.py
+++ b/tests/unit/client/workbench/__init__.py
@@ -1,0 +1,1 @@
+# Test module for workbench client unit tests

--- a/tests/unit/client/workbench/ewes/__init__.py
+++ b/tests/unit/client/workbench/ewes/__init__.py
@@ -1,0 +1,1 @@
+# Test module for EWES client unit tests

--- a/tests/unit/client/workbench/ewes/test_run_events_deserialization.py
+++ b/tests/unit/client/workbench/ewes/test_run_events_deserialization.py
@@ -1,0 +1,409 @@
+import json
+import uuid
+from datetime import datetime
+from typing import Dict, Any
+
+import pytest
+from pydantic import ValidationError
+
+from dnastack.client.workbench.ewes.models import (
+    RunEvent, EventType, State,
+    RunSubmittedMetadata, PreprocessingMetadata, ErrorOccurredMetadata,
+    StateTransitionMetadata, EngineStatusUpdateMetadata, RunSubmittedToEngineMetadata,
+    ExtendedRunEvents, SampleId
+)
+
+
+class TestRunEventDeserialization:
+    """Test suite for RunEvent model deserialization with discriminated unions."""
+
+    @pytest.fixture
+    def base_run_event_data(self) -> Dict[str, Any]:
+        """Base run event data structure."""
+        return {
+            "id": str(uuid.uuid4()),
+            "created_at": "2023-11-20T10:00:00Z",
+        }
+
+    @pytest.fixture
+    def sample_run_submitted_data(self, base_run_event_data) -> Dict[str, Any]:
+        """Sample RUN_SUBMITTED event data."""
+        return {
+            **base_run_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED",
+                "message": "Run submitted successfully",
+                "start_time": "2023-11-20T10:00:00Z",
+                "submitted_by": "user@example.com",
+                "state": "QUEUED",
+                "workflow_id": "workflow-123",
+                "workflow_version_id": "version-456",
+                "workflow_url": "https://dockstore.org/api/ga4gh/trs/v2/tools/github.com%2Fuser%2Frepo/versions/main",
+                "workflow_name": "example-workflow",
+                "workflow_version": "v1.0.0",
+                "workflow_authors": ["Author One", "Author Two"],
+                "workflow_type": "WDL",
+                "workflow_type_version": "1.0",
+                "tags": {
+                    "project": "test-project",
+                    "environment": "dev"
+                },
+                "sample_ids": [
+                    {
+                        "id": "sample-1",
+                        "storage_account_id": "storage-123"
+                    },
+                    {
+                        "id": "sample-2",
+                        "storage_account_id": "storage-456"
+                    }
+                ]
+            }
+        }
+
+    @pytest.fixture
+    def sample_preprocessing_data(self, base_run_event_data) -> Dict[str, Any]:
+        """Sample PREPROCESSING event data."""
+        return {
+            **base_run_event_data,
+            "event_type": "PREPROCESSING",
+            "metadata": {
+                "event_type": "PREPROCESSING",
+                "message": "Preprocessing workflow parameters",
+                "outcome": "SUCCESS"
+            }
+        }
+
+    @pytest.fixture
+    def sample_error_occurred_data(self, base_run_event_data) -> Dict[str, Any]:
+        """Sample ERROR_OCCURRED event data."""
+        return {
+            **base_run_event_data,
+            "event_type": "ERROR_OCCURRED",
+            "metadata": {
+                "event_type": "ERROR_OCCURRED",
+                "message": "Workflow execution failed",
+                "errors": [
+                    "Task 'process_sample' failed with exit code 1",
+                    "Input file not found: /data/input.txt"
+                ]
+            }
+        }
+
+    @pytest.fixture
+    def sample_state_transition_data(self, base_run_event_data) -> Dict[str, Any]:
+        """Sample STATE_TRANSITION event data."""
+        return {
+            **base_run_event_data,
+            "event_type": "STATE_TRANSITION",
+            "metadata": {
+                "event_type": "STATE_TRANSITION",
+                "message": "Workflow state changed",
+                "end_time": "2023-11-20T10:30:00Z",
+                "old_state": "RUNNING",
+                "new_state": "COMPLETE",
+                "errors": []
+            }
+        }
+
+    @pytest.fixture
+    def sample_engine_status_update_data(self, base_run_event_data) -> Dict[str, Any]:
+        """Sample ENGINE_STATUS_UPDATE event data."""
+        return {
+            **base_run_event_data,
+            "event_type": "ENGINE_STATUS_UPDATE",
+            "metadata": {
+                "event_type": "ENGINE_STATUS_UPDATE",
+                "message": "Engine status updated"
+            }
+        }
+
+    @pytest.fixture
+    def sample_run_submitted_to_engine_data(self, base_run_event_data) -> Dict[str, Any]:
+        """Sample RUN_SUBMITTED_TO_ENGINE event data."""
+        return {
+            **base_run_event_data,
+            "event_type": "RUN_SUBMITTED_TO_ENGINE",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED_TO_ENGINE",
+                "message": "Run submitted to execution engine"
+            }
+        }
+
+    def test_run_submitted_event_deserialization(self, sample_run_submitted_data):
+        """Test deserialization of RUN_SUBMITTED event."""
+        event = RunEvent(**sample_run_submitted_data)
+        
+        assert event.event_type == EventType.RUN_SUBMITTED
+        assert isinstance(event.metadata, RunSubmittedMetadata)
+        assert event.metadata.event_type == EventType.RUN_SUBMITTED
+        assert event.metadata.message == "Run submitted successfully"
+        assert event.metadata.submitted_by == "user@example.com"
+        assert event.metadata.state == State.QUEUED
+        assert event.metadata.workflow_name == "example-workflow"
+        assert event.metadata.workflow_authors == ["Author One", "Author Two"]
+        assert event.metadata.tags == {"project": "test-project", "environment": "dev"}
+        assert len(event.metadata.sample_ids) == 2
+        assert event.metadata.sample_ids[0].id == "sample-1"
+        assert event.metadata.sample_ids[0].storage_account_id == "storage-123"
+
+    def test_preprocessing_event_deserialization(self, sample_preprocessing_data):
+        """Test deserialization of PREPROCESSING event."""
+        event = RunEvent(**sample_preprocessing_data)
+        
+        assert event.event_type == EventType.PREPROCESSING
+        assert isinstance(event.metadata, PreprocessingMetadata)
+        assert event.metadata.event_type == EventType.PREPROCESSING
+        assert event.metadata.outcome == "SUCCESS"
+
+    def test_error_occurred_event_deserialization(self, sample_error_occurred_data):
+        """Test deserialization of ERROR_OCCURRED event."""
+        event = RunEvent(**sample_error_occurred_data)
+        
+        assert event.event_type == EventType.ERROR_OCCURRED
+        assert isinstance(event.metadata, ErrorOccurredMetadata)
+        assert event.metadata.event_type == EventType.ERROR_OCCURRED
+        assert len(event.metadata.errors) == 2
+        assert "Task 'process_sample' failed" in event.metadata.errors[0]
+
+    def test_state_transition_event_deserialization(self, sample_state_transition_data):
+        """Test deserialization of STATE_TRANSITION event."""
+        event = RunEvent(**sample_state_transition_data)
+        
+        assert event.event_type == EventType.STATE_TRANSITION
+        assert isinstance(event.metadata, StateTransitionMetadata)
+        assert event.metadata.event_type == EventType.STATE_TRANSITION
+        assert event.metadata.old_state == State.RUNNING
+        assert event.metadata.new_state == State.COMPLETE
+        assert event.metadata.errors == []
+
+    def test_engine_status_update_event_deserialization(self, sample_engine_status_update_data):
+        """Test deserialization of ENGINE_STATUS_UPDATE event."""
+        event = RunEvent(**sample_engine_status_update_data)
+        
+        assert event.event_type == EventType.ENGINE_STATUS_UPDATE
+        assert isinstance(event.metadata, EngineStatusUpdateMetadata)
+        assert event.metadata.event_type == EventType.ENGINE_STATUS_UPDATE
+
+    def test_run_submitted_to_engine_event_deserialization(self, sample_run_submitted_to_engine_data):
+        """Test deserialization of RUN_SUBMITTED_TO_ENGINE event."""
+        event = RunEvent(**sample_run_submitted_to_engine_data)
+        
+        assert event.event_type == EventType.RUN_SUBMITTED_TO_ENGINE
+        assert isinstance(event.metadata, RunSubmittedToEngineMetadata)
+        assert event.metadata.event_type == EventType.RUN_SUBMITTED_TO_ENGINE
+
+    def test_extended_run_events_deserialization(self, sample_run_submitted_data, sample_error_occurred_data):
+        """Test deserialization of ExtendedRunEvents containing multiple events."""
+        events_data = {
+            "events": [
+                sample_run_submitted_data,
+                sample_error_occurred_data
+            ]
+        }
+        
+        extended_run_events = ExtendedRunEvents(**events_data)
+        
+        assert len(extended_run_events.events) == 2
+        assert extended_run_events.events[0].event_type == EventType.RUN_SUBMITTED
+        assert extended_run_events.events[1].event_type == EventType.ERROR_OCCURRED
+
+    def test_invalid_event_type_raises_validation_error(self, base_run_event_data):
+        """Test that invalid event type raises ValidationError."""
+        invalid_data = {
+            **base_run_event_data,
+            "event_type": "INVALID_EVENT_TYPE",
+            "metadata": {
+                "event_type": "INVALID_EVENT_TYPE",
+                "message": "This should fail"
+            }
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**invalid_data)
+        
+        assert "event_type" in str(exc_info.value)
+
+
+    def test_missing_metadata_raises_validation_error(self, base_run_event_data):
+        """Test that missing metadata field raises ValidationError."""
+        invalid_data = {
+            **base_run_event_data,
+            "event_type": "RUN_SUBMITTED"
+            # Missing metadata field
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**invalid_data)
+        
+        assert "metadata" in str(exc_info.value)
+
+    def test_optional_fields_can_be_none(self, base_run_event_data):
+        """Test that optional fields can be None without raising errors."""
+        minimal_data = {
+            **base_run_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED",
+                # All other fields are optional and should default to None
+            }
+        }
+        
+        event = RunEvent(**minimal_data)
+        assert event.metadata.message is None
+        assert event.metadata.submitted_by is None
+        assert event.metadata.workflow_authors is None
+        assert event.metadata.tags is None
+        assert event.metadata.sample_ids is None
+
+    def test_sample_id_deserialization(self):
+        """Test SampleId model deserialization."""
+        sample_data = {
+            "id": "sample-123",
+            "storage_account_id": "storage-456"
+        }
+        
+        sample_id = SampleId(**sample_data)
+        assert sample_id.id == "sample-123"
+        assert sample_id.storage_account_id == "storage-456"
+
+    def test_sample_id_optional_fields(self):
+        """Test SampleId with optional fields."""
+        minimal_sample_data = {}
+        
+        sample_id = SampleId(**minimal_sample_data)
+        assert sample_id.id is None
+        assert sample_id.storage_account_id is None
+
+    def test_datetime_parsing(self, base_run_event_data):
+        """Test that datetime strings are properly parsed."""
+        data_with_datetime = {
+            **base_run_event_data,
+            "created_at": "2023-11-20T10:00:00.123456Z",
+            "event_type": "PREPROCESSING",
+            "metadata": {
+                "event_type": "PREPROCESSING",
+                "outcome": "SUCCESS"
+            }
+        }
+        
+        event = RunEvent(**data_with_datetime)
+        assert isinstance(event.created_at, datetime)
+        assert event.created_at.year == 2023
+        assert event.created_at.month == 11
+        assert event.created_at.day == 20
+
+    def test_state_enum_validation(self, base_run_event_data):
+        """Test that State enum values are properly validated."""
+        valid_states = ["QUEUED", "RUNNING", "COMPLETE", "CANCELED", "EXECUTOR_ERROR"]
+        
+        for state in valid_states:
+            data = {
+                **base_run_event_data,
+                "event_type": "STATE_TRANSITION",
+                "metadata": {
+                    "event_type": "STATE_TRANSITION",
+                    "old_state": "QUEUED",
+                    "new_state": state
+                }
+            }
+            
+            event = RunEvent(**data)
+            assert event.metadata.new_state.value == state
+
+    def test_invalid_state_raises_validation_error(self, base_run_event_data):
+        """Test that invalid State values raise ValidationError."""
+        invalid_data = {
+            **base_run_event_data,
+            "event_type": "STATE_TRANSITION",
+            "metadata": {
+                "event_type": "STATE_TRANSITION",
+                "old_state": "INVALID_STATE",
+                "new_state": "COMPLETE"
+            }
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**invalid_data)
+        
+        assert "old_state" in str(exc_info.value)
+
+    @pytest.mark.parametrize("event_type,metadata_class", [
+        (EventType.RUN_SUBMITTED, RunSubmittedMetadata),
+        (EventType.PREPROCESSING, PreprocessingMetadata),
+        (EventType.ERROR_OCCURRED, ErrorOccurredMetadata),
+        (EventType.STATE_TRANSITION, StateTransitionMetadata),
+        (EventType.ENGINE_STATUS_UPDATE, EngineStatusUpdateMetadata),
+        (EventType.RUN_SUBMITTED_TO_ENGINE, RunSubmittedToEngineMetadata),
+    ])
+    def test_discriminator_mapping(self, base_run_event_data, event_type, metadata_class):
+        """Test that discriminator correctly maps event types to metadata classes."""
+        data = {
+            **base_run_event_data,
+            "event_type": event_type.value,
+            "metadata": {
+                "event_type": event_type.value,
+                "message": f"Test {event_type.value} event"
+            }
+        }
+        
+        event = RunEvent(**data)
+        assert isinstance(event.metadata, metadata_class)
+        assert event.metadata.event_type == event_type
+
+    def test_json_serialization_roundtrip(self, sample_run_submitted_data):
+        """Test that RunEvent can be serialized to JSON and deserialized back."""
+        # First deserialization
+        event = RunEvent(**sample_run_submitted_data)
+        
+        # Serialize to JSON
+        json_str = event.json()
+        json_dict = json.loads(json_str)
+        
+        # Deserialize from JSON
+        event_from_json = RunEvent(**json_dict)
+        
+        # Verify they're equivalent
+        assert event.id == event_from_json.id
+        assert event.event_type == event_from_json.event_type
+        assert event.created_at == event_from_json.created_at
+        assert type(event.metadata) is type(event_from_json.metadata)
+        assert event.metadata.message == event_from_json.metadata.message
+
+    def test_dict_serialization_roundtrip(self, sample_error_occurred_data):
+        """Test that RunEvent can be converted to dict and back."""
+        # First deserialization
+        event = RunEvent(**sample_error_occurred_data)
+        
+        # Convert to dict
+        event_dict = event.dict()
+        
+        # Create new instance from dict
+        event_from_dict = RunEvent(**event_dict)
+        
+        # Verify they're equivalent
+        assert event.id == event_from_dict.id
+        assert event.event_type == event_from_dict.event_type
+        assert event.metadata.errors == event_from_dict.metadata.errors
+
+    def test_empty_events_list(self):
+        """Test ExtendedRunEvents with empty events list."""
+        data = {"events": []}
+        
+        extended_run_events = ExtendedRunEvents(**data)
+        assert extended_run_events.events == []
+
+    def test_none_events_list(self):
+        """Test ExtendedRunEvents with None events list."""
+        data = {"events": None}
+        
+        extended_run_events = ExtendedRunEvents(**data)
+        assert extended_run_events.events is None
+
+    def test_no_events_field(self):
+        """Test ExtendedRunEvents with no events field."""
+        data = {}
+        
+        extended_run_events = ExtendedRunEvents(**data)
+        assert extended_run_events.events is None

--- a/tests/unit/client/workbench/ewes/test_run_events_edge_cases.py
+++ b/tests/unit/client/workbench/ewes/test_run_events_edge_cases.py
@@ -1,0 +1,515 @@
+import json
+import uuid
+from datetime import datetime
+from typing import Dict, Any
+
+import pytest
+from pydantic import ValidationError
+
+from dnastack.client.workbench.ewes.models import (
+    RunEvent, EventType, State, ExtendedRunEvents,
+    RunSubmittedMetadata, StateTransitionMetadata,
+)
+
+
+class TestRunEventEdgeCases:
+    """Test edge cases, error handling, and boundary conditions for RunEvent models."""
+
+    @pytest.fixture
+    def base_event_data(self) -> Dict[str, Any]:
+        """Basic event data structure."""
+        return {
+            "id": str(uuid.uuid4()),
+            "created_at": "2023-11-20T10:00:00Z"
+        }
+
+    def test_invalid_discriminator_value_in_metadata(self, base_event_data):
+        """Test that invalid discriminator value in metadata raises ValidationError."""
+        invalid_data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "INVALID_TYPE",  # This doesn't match any EventType enum
+                "message": "This should fail"
+            }
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**invalid_data)
+        
+        error_str = str(exc_info.value).lower()
+        assert any(keyword in error_str for keyword in ["discriminator", "invalid", "literal"])
+
+    def test_missing_discriminator_field_in_metadata(self, base_event_data):
+        """Test that missing discriminator field in metadata raises ValidationError."""
+        invalid_data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                # Missing "event_type" field which is the discriminator
+                "message": "This should fail"
+            }
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**invalid_data)
+        
+        assert "event_type" in str(exc_info.value)
+
+    def test_null_metadata_field(self, base_event_data):
+        """Test that null metadata field raises ValidationError."""
+        invalid_data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": None
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**invalid_data)
+        
+        assert "metadata" in str(exc_info.value)
+
+    def test_empty_metadata_object(self, base_event_data):
+        """Test behavior with empty metadata object."""
+        invalid_data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {}
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**invalid_data)
+        
+        # Should fail because event_type discriminator is missing
+        assert "event_type" in str(exc_info.value)
+
+    def test_extra_fields_in_metadata(self, base_event_data):
+        """Test that extra fields in metadata are handled gracefully."""
+        data_with_extra = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED",
+                "message": "Valid message",
+                "extra_field": "This should be ignored",
+                "another_extra": {"nested": "object"}
+            }
+        }
+        
+        # Pydantic should handle extra fields based on model configuration
+        # By default, extra fields are ignored unless model is configured otherwise
+        event = RunEvent(**data_with_extra)
+        assert event.metadata.message == "Valid message"
+        
+        # Extra fields should not be accessible as attributes
+        assert not hasattr(event.metadata, 'extra_field')
+
+    def test_malformed_datetime_string(self, base_event_data):
+        """Test behavior with malformed datetime strings."""
+        invalid_datetime_data = {
+            **base_event_data,
+            "created_at": "not-a-datetime",
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED"
+            }
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**invalid_datetime_data)
+        
+        assert "created_at" in str(exc_info.value)
+
+    def test_various_datetime_formats(self, base_event_data):
+        """Test different valid datetime formats."""
+        valid_formats = [
+            "2023-11-20T10:00:00Z",
+            "2023-11-20T10:00:00.000Z",
+            "2023-11-20T10:00:00.123456Z",
+            "2023-11-20T10:00:00+00:00",
+            "2023-11-20T10:00:00-05:00",
+        ]
+        
+        for dt_format in valid_formats:
+            data = {
+                **base_event_data,
+                "created_at": dt_format,
+                "event_type": "RUN_SUBMITTED",
+                "metadata": {
+                    "event_type": "RUN_SUBMITTED"
+                }
+            }
+            
+            event = RunEvent(**data)
+            assert isinstance(event.created_at, datetime)
+
+    def test_large_event_id(self, base_event_data):
+        """Test handling of very long event IDs."""
+        long_id = "a" * 1000  # Very long ID
+        data = {
+            **base_event_data,
+            "id": long_id,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED"
+            }
+        }
+        
+        event = RunEvent(**data)
+        assert event.id == long_id
+
+    def test_special_characters_in_fields(self, base_event_data):
+        """Test handling of special characters in string fields."""
+        special_message = "Message with special chars: αβγ 中文 🎉 \n\t\"'\\/"
+        data = {
+            **base_event_data,
+            "event_type": "ERROR_OCCURRED",
+            "metadata": {
+                "event_type": "ERROR_OCCURRED",
+                "message": special_message,
+                "errors": ["Error with unicode: αβγ", "Error with newline\nhere"]
+            }
+        }
+        
+        event = RunEvent(**data)
+        assert event.metadata.message == special_message
+        assert len(event.metadata.errors) == 2
+        assert "unicode: αβγ" in event.metadata.errors[0]
+
+    def test_maximum_list_sizes(self, base_event_data):
+        """Test handling of large lists in metadata."""
+        large_errors_list = [f"Error {i}" for i in range(1000)]
+        large_authors_list = [f"Author {i}" for i in range(100)]
+        
+        data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED",
+                "workflow_authors": large_authors_list,
+            }
+        }
+        
+        event = RunEvent(**data)
+        assert len(event.metadata.workflow_authors) == 100
+        
+        # Test large errors list
+        error_data = {
+            **base_event_data,
+            "event_type": "ERROR_OCCURRED",
+            "metadata": {
+                "event_type": "ERROR_OCCURRED",
+                "errors": large_errors_list
+            }
+        }
+        
+        error_event = RunEvent(**error_data)
+        assert len(error_event.metadata.errors) == 1000
+
+    def test_nested_dict_in_tags(self, base_event_data):
+        """Test handling of complex nested structures in tags."""
+        complex_tags = {
+            "simple_key": "simple_value",
+            "nested_key": "nested_value",
+            "special_chars": "value with spaces & symbols!",
+            "unicode_key": "ηλληνικά",
+        }
+        
+        data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED",
+                "tags": complex_tags
+            }
+        }
+        
+        event = RunEvent(**data)
+        assert event.metadata.tags == complex_tags
+        assert event.metadata.tags["unicode_key"] == "ηλληνικά"
+
+    def test_boundary_states_in_transition(self, base_event_data):
+        """Test all possible State enum combinations in STATE_TRANSITION events."""
+        all_states = [state for state in State]
+        
+        for old_state in all_states:
+            for new_state in all_states:
+                if old_state != new_state:  # Skip same-state transitions
+                    data = {
+                        **base_event_data,
+                        "id": f"{base_event_data['id']}-{old_state.value}-{new_state.value}",
+                        "event_type": "STATE_TRANSITION",
+                        "metadata": {
+                            "event_type": "STATE_TRANSITION",
+                            "old_state": old_state.value,
+                            "new_state": new_state.value
+                        }
+                    }
+                    
+                    event = RunEvent(**data)
+                    assert event.metadata.old_state == old_state
+                    assert event.metadata.new_state == new_state
+
+    def test_json_deserialization_from_api_response(self):
+        """Test deserialization from JSON as would come from API response."""
+        # Simulate actual API response format
+        api_response_json = '''
+        {
+            "events": [
+                {
+                    "id": "event-1",
+                    "created_at": "2023-11-20T10:00:00.123Z",
+                    "event_type": "RUN_SUBMITTED",
+                    "metadata": {
+                        "event_type": "RUN_SUBMITTED",
+                        "message": null,
+                        "start_time": "2023-11-20T10:00:00.123Z",
+                        "submitted_by": "user@example.com",
+                        "state": "QUEUED",
+                        "workflow_name": "hello-world",
+                        "workflow_authors": ["John Doe", "Jane Smith"],
+                        "tags": {
+                            "project": "test-project",
+                            "priority": "high"
+                        },
+                        "sample_ids": [
+                            {
+                                "id": "sample-1",
+                                "storage_account_id": "storage-123"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "event-2",
+                    "created_at": "2023-11-20T10:01:00.456Z",
+                    "event_type": "STATE_TRANSITION",
+                    "metadata": {
+                        "event_type": "STATE_TRANSITION",
+                        "old_state": "QUEUED",
+                        "new_state": "RUNNING",
+                        "errors": []
+                    }
+                }
+            ]
+        }
+        '''
+        
+        response_data = json.loads(api_response_json)
+        extended_run_events = ExtendedRunEvents(**response_data)
+        
+        assert len(extended_run_events.events) == 2
+        
+        # Test first event
+        first_event = extended_run_events.events[0]
+        assert first_event.event_type == EventType.RUN_SUBMITTED
+        assert isinstance(first_event.metadata, RunSubmittedMetadata)
+        assert first_event.metadata.submitted_by == "user@example.com"
+        assert first_event.metadata.workflow_name == "hello-world"
+        assert len(first_event.metadata.workflow_authors) == 2
+        assert first_event.metadata.tags["project"] == "test-project"
+        assert len(first_event.metadata.sample_ids) == 1
+        
+        # Test second event
+        second_event = extended_run_events.events[1]
+        assert second_event.event_type == EventType.STATE_TRANSITION
+        assert isinstance(second_event.metadata, StateTransitionMetadata)
+        assert second_event.metadata.old_state == State.QUEUED
+        assert second_event.metadata.new_state == State.RUNNING
+        assert second_event.metadata.errors == []
+
+    def test_case_sensitivity_in_enum_values(self, base_event_data):
+        """Test that enum values are case-sensitive."""
+        # Test with incorrect case
+        invalid_case_data = {
+            **base_event_data,
+            "event_type": "run_submitted",  # lowercase instead of uppercase
+            "metadata": {
+                "event_type": "run_submitted",
+                "message": "This should fail"
+            }
+        }
+        
+        with pytest.raises(ValidationError):
+            RunEvent(**invalid_case_data)
+        
+        # Test with mixed case
+        invalid_mixed_case_data = {
+            **base_event_data,
+            "event_type": "Run_Submitted",  # mixed case
+            "metadata": {
+                "event_type": "Run_Submitted",
+                "message": "This should fail"
+            }
+        }
+        
+        with pytest.raises(ValidationError):
+            RunEvent(**invalid_mixed_case_data)
+
+    def test_memory_usage_with_large_events(self, base_event_data):
+        """Test memory usage doesn't explode with large event data."""
+        # Create a large event with lots of data
+        large_data = {
+            **base_event_data,
+            "event_type": "ERROR_OCCURRED",
+            "metadata": {
+                "event_type": "ERROR_OCCURRED",
+                "message": "A" * 10000,  # 10KB message
+                "errors": [f"Error {i}: {'X' * 100}" for i in range(100)]  # ~10KB of error messages
+            }
+        }
+        
+        # This should not raise memory errors or take excessive time
+        event = RunEvent(**large_data)
+        assert len(event.metadata.message) == 10000
+        assert len(event.metadata.errors) == 100
+        
+        # Test serialization doesn't break
+        event_dict = event.dict()
+        assert len(event_dict["metadata"]["message"]) == 10000
+
+    @pytest.mark.parametrize("field_type,field_name,empty_value", [
+        ("list", "workflow_authors", None),
+        ("list", "workflow_authors", []),
+        ("list", "sample_ids", None),
+        ("list", "sample_ids", []),
+        ("dict", "tags", None),
+        ("dict", "tags", {}),
+    ])
+    def test_optional_list_and_dict_fields(self, base_event_data, field_type, field_name, empty_value):
+        """Test optional list and dict fields with various empty values."""
+        data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED",
+                field_name: empty_value
+            }
+        }
+        
+        event = RunEvent(**data)
+        actual_value = getattr(event.metadata, field_name)
+        assert actual_value == empty_value, f"Expected {field_name} to be {empty_value}, got {actual_value}"
+
+    def test_concurrent_deserialization(self, base_event_data):
+        """Test thread safety of deserialization (basic smoke test)."""
+        import threading
+        import time
+        
+        def deserialize_event(thread_id):
+            data = {
+                **base_event_data,
+                "id": f"{base_event_data['id']}-thread-{thread_id}",
+                "event_type": "RUN_SUBMITTED",
+                "metadata": {
+                    "event_type": "RUN_SUBMITTED",
+                    "message": f"Message from thread {thread_id}"
+                }
+            }
+            
+            for _ in range(10):  # Create multiple events per thread
+                event = RunEvent(**data)
+                assert event.metadata.message == f"Message from thread {thread_id}"
+                time.sleep(0.001)  # Small delay to increase chance of race conditions
+        
+        threads = []
+        for i in range(5):
+            thread = threading.Thread(target=deserialize_event, args=(i,))
+            threads.append(thread)
+            thread.start()
+        
+        for thread in threads:
+            thread.join()
+
+    def test_deep_copy_behavior(self, base_event_data):
+        """Test that events can be deep copied without issues."""
+        import copy
+        
+        original_data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED",
+                "workflow_authors": ["Original Author"],
+                "tags": {"original": "tag"}
+            }
+        }
+        
+        original_event = RunEvent(**original_data)
+        copied_event = copy.deepcopy(original_event)
+        
+        # Verify they're equal but not the same object
+        assert original_event.id == copied_event.id
+        assert original_event.event_type == copied_event.event_type
+        assert original_event.metadata.workflow_authors == copied_event.metadata.workflow_authors
+        assert original_event is not copied_event
+        assert original_event.metadata is not copied_event.metadata
+
+    def test_hash_behavior(self, base_event_data):
+        """Test that events can be used in sets and as dict keys."""
+        data = {
+            **base_event_data,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED"
+            }
+        }
+        
+        event1 = RunEvent(**data)
+        event2 = RunEvent(**data)  # Same data
+        
+        # These should be equal based on their data
+        # Note: Pydantic models are hashable if they're frozen, otherwise this might fail
+        try:
+            event_set = {event1, event2}
+            event_dict = {event1: "value1", event2: "value2"}
+            # If we get here, the objects are hashable
+            assert len(event_set) <= 2  # Could be 1 if they're considered equal
+            assert len(event_dict) <= 2
+        except TypeError:
+            # If TypeError is raised, the objects aren't hashable (which is also fine)
+            pytest.skip("RunEvent objects are not hashable")
+
+    def test_validation_error_messages_are_helpful(self, base_event_data):
+        """Test that validation error messages provide useful information."""
+        # Test with missing required field
+        incomplete_data = {
+            **base_event_data,
+            # Missing event_type field
+            "metadata": {
+                "event_type": "RUN_SUBMITTED"
+            }
+        }
+        
+        with pytest.raises(ValidationError) as exc_info:
+            RunEvent(**incomplete_data)
+        
+        error_msg = str(exc_info.value)
+        assert "event_type" in error_msg
+        assert "field required" in error_msg.lower() or "missing" in error_msg.lower()
+
+    def test_serialization_preserves_precision(self, base_event_data):
+        """Test that serialization/deserialization preserves data precision."""
+        precise_timestamp = "2023-11-20T10:00:00.123456789Z"
+        data = {
+            **base_event_data,
+            "created_at": precise_timestamp,
+            "event_type": "RUN_SUBMITTED",
+            "metadata": {
+                "event_type": "RUN_SUBMITTED",
+                "start_time": precise_timestamp
+            }
+        }
+        
+        event = RunEvent(**data)
+        serialized = event.json()
+        deserialized = RunEvent(**json.loads(serialized))
+        
+        # Verify timestamps are preserved (noting that datetime precision might be limited)
+        assert deserialized.created_at is not None
+        assert deserialized.metadata.start_time is not None
+        
+        # The exact precision might vary based on datetime implementation
+        # But the values should be very close
+        original_dt = datetime.fromisoformat(precise_timestamp.replace('Z', '+00:00'))
+        assert abs((deserialized.created_at - original_dt).total_seconds()) < 0.001


### PR DESCRIPTION
## Summary

This PR fixes incomplete RunEvent data models in the CLI that were causing validation errors when processing workflow events.

## Key Changes

### Model Improvements
- **Fixed discriminated union handling** for RunEvent metadata deserialization
- **Ensured all 6 event types** properly map to their corresponding metadata classes:
  - `RUN_SUBMITTED` → `RunSubmittedMetadata`
  - `PREPROCESSING` → `PreprocessingMetadata` 
  - `ERROR_OCCURRED` → `ErrorOccurredMetadata`
  - `STATE_TRANSITION` → `StateTransitionMetadata`
  - `ENGINE_STATUS_UPDATE` → `EngineStatusUpdateMetadata`
  - `RUN_SUBMITTED_TO_ENGINE` → `RunSubmittedToEngineMetadata`
- **Improved validation and error handling** for malformed event data

### Testing
- Added comprehensive test coverage (51 unit tests) to prevent regression
- Enhanced existing e2e tests to validate CLI/client integration
- Verified serialization integrity across all event types

## Problem Solved

The CLI was experiencing validation errors when processing RunEvents due to incomplete discriminated union model configuration, resulting in failed deserialization and missing state information in CLI output.

🤖 Generated with [Claude Code](https://claude.ai/code)