### PR TITLE
[CU-86b6zdqhm] Migrate E2E tests to workbench alpha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,15 +115,15 @@ test-setup: check-uv
 
 .PHONY: test-unit
 test-unit:
-	uv run pytest tests -m unit -v
+	uv run pytest tests -m unit -v -n auto
 
 .PHONY: test-unit-cov
 test-unit-cov:
-	uv run pytest tests -m unit -v --cov=dnastack --cov-report=html --cov-report=term-missing
+	uv run pytest tests -m unit -v --cov=dnastack --cov-report=html --cov-report=term-missing -n auto
 
 .PHONY: test-unit-watch
 test-unit-watch:
-	uv run pytest-watch tests -m unit -v
+	uv run pytest-watch tests -m unit -v -n auto
 
 .PHONY: lint
 lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ test = [
     "pytest-cov>=4.0.0",
     "pytest-xdist>=3.0.0",
     "pytest-mock>=3.10.0",
+    "pytest-sugar>=1.1.1",
     "pytest-timeout>=2.1.0",
     "pytest-watch>=4.2.0",
     "responses>=0.23.0",

--- a/tests/e2e_tests/cli/auth_utils.py
+++ b/tests/e2e_tests/cli/auth_utils.py
@@ -128,7 +128,8 @@ def _login_via_personal_access_token(driver: WebDriver, email: str, token: str, 
         wallet_login_uri = urljoin(device_code_url, "/login")
         driver.get(f'{wallet_login_uri}')
     WebDriverWait(driver, 10).until(
-        EC.visibility_of_element_located((By.XPATH, "//a[contains(@href, 'login')]"))
+        EC.presence_of_element_located((By.CSS_SELECTOR, "form[name='token']")),
+        message='Expecting token login form'
     )
     driver.execute_script(
         f"document.querySelector('form[name=\"token\"] input[name=\"token\"]').value = '{token}';"
@@ -160,8 +161,8 @@ def confirm_device_code(device_code_url: str, email: str, token: str):
         driver.get(device_code_url)
         # Assert login page is loaded
         WebDriverWait(driver, 10).until(
-            EC.visibility_of_element_located((By.XPATH, "//a[contains(@href, 'login')]")),
-            message='Expecting login page'
+            EC.presence_of_element_located((By.CSS_SELECTOR, "form[name='token']")),
+            message='Expecting token login form'
         )
         # Login via personal access token
         _login_via_personal_access_token(driver=driver, email=email, token=token, device_code_url=device_code_url)

--- a/tests/e2e_tests/cli/base.py
+++ b/tests/e2e_tests/cli/base.py
@@ -21,7 +21,7 @@ from tests.util.exam_helper_for_workbench import BaseWorkbenchTestCase
 
 
 class CliTestCase(BaseTestCase):
-    _runner = CliRunner(mix_stderr=False)
+    _runner = CliRunner()
 
     @classmethod
     def get_context_manager(cls) -> BaseContextManager:

--- a/uv.lock
+++ b/uv.lock
@@ -276,6 +276,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-sugar" },
     { name = "pytest-timeout" },
     { name = "pytest-watch" },
     { name = "pytest-xdist" },
@@ -289,6 +290,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-sugar" },
     { name = "pytest-timeout" },
     { name = "pytest-watch" },
     { name = "pytest-xdist" },
@@ -331,6 +333,7 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-mock", specifier = ">=3.10.0" },
+    { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-timeout", specifier = ">=2.1.0" },
     { name = "pytest-watch", specifier = ">=4.2.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
@@ -344,6 +347,7 @@ test = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-mock", specifier = ">=3.10.0" },
+    { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-timeout", specifier = ">=2.1.0" },
     { name = "pytest-watch", specifier = ">=4.2.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
@@ -1166,6 +1170,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-sugar"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1423,6 +1440,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/6c/3d75c196ac07ac8749600b60b03f4f6094d54e132c4d94ebac6ee0e0add0/termcolor-3.1.0.tar.gz", hash = "sha256:6a6dd7fbee581909eeec6a756cff1d7f7c376063b14e4a298dc4980309e55970", size = 14324, upload-time = "2025-04-30T11:37:53.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl", hash = "sha256:591dd26b5c2ce03b9e43f391264626557873ce1d379019786f99b0c2bee140aa", size = 7684, upload-time = "2025-04-30T11:37:52.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!IMPORTANT]
> *This PR was developed with AI assistance provided by [Claude Code](https://claude.ai/code)* 

## Summary
- Fixed device code authentication selector to be compatible with workbench alpha UI
- Added pytest-sugar for improved test output visualization
- Enabled parallel test execution using pytest-xdist -n auto flag
- Simplified CliRunner configuration by removing mix_stderr parameter

## Changes

### Authentication Compatibility
Updated the E2E test authentication flow to check for the presence of the hidden token form using CSS selector instead of checking for a login link. This ensures compatibility with the workbench alpha authentication UI.

**File**: `tests/e2e_tests/cli/auth_utils.py`
- Changed from checking visibility of login link to checking presence of token form
- Updated selector from XPath to CSS selector for more reliable element detection

### Test Infrastructure Improvements
Enhanced the testing infrastructure with better tooling and performance:

**File**: `Makefile`
- Updated test-unit, test-unit-cov, and test-unit-watch targets to use `-n auto` flag
- Enables automatic parallel test execution based on available CPU cores

**File**: `pyproject.toml`, `uv.lock`
- Added pytest-sugar dependency for better test output with real-time progress bars and instant failure feedback

### Test Configuration
**File**: `tests/e2e_tests/cli/base.py`
- Removed `mix_stderr=False` parameter from CliRunner initialization
- Uses default behavior for stderr handling, simplifying test configuration

## Test plan
- [x] Unit tests pass locally
- [x] Linting passes
- [ ] E2E tests pass against workbench alpha environment
- [ ] Device code authentication flow works correctly with new selector
- [ ] Parallel test execution completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)