### PR TITLE
[CU-86b5yw7nc] Add --label filter to workflows list and versions list

### DIFF
--- a/dnastack/cli/commands/workbench/workflows/commands.py
+++ b/dnastack/cli/commands/workbench/workflows/commands.py
@@ -57,6 +57,14 @@ def init_workflows_commands(group: Group):
                 help='Include deleted workflows in the list',
                 type=bool,
             ),
+            ArgumentSpec(
+                name='label',
+                arg_names=['--label'],
+                help='Filter by label. This flag can be repeated to filter by multiple labels (e.g., --label tag1 --label tag2). '
+                     'A workflow is included if the label appears on the workflow itself, any of its versions, or any of its transformations. '
+                     'Use "omics workbench workflows versions list --label <label>" to identify which version or transformation matched.',
+                multiple=True,
+            ),
             CONTEXT_ARG,
             SINGLE_ENDPOINT_ID_ARG,
         ]
@@ -71,6 +79,7 @@ def init_workflows_commands(group: Group):
                        order: Optional[str],
                        search: Optional[str],
                        source: Optional[WorkflowSource],
+                       label: List[str] = (),
                        include_deleted: Optional[bool] = False):
         """
         List workflows
@@ -97,7 +106,8 @@ def init_workflows_commands(group: Group):
             direction=order_direction,
             source=source,
             search=search,
-            deleted=include_deleted
+            deleted=include_deleted,
+            label=list(label) if label else None,
         )
         show_iterator(output_format=OutputFormat.JSON,
                       iterator=workflows_client.list_workflows(list_options=list_options, max_results=max_results))

--- a/dnastack/cli/commands/workbench/workflows/versions/commands.py
+++ b/dnastack/cli/commands/workbench/workflows/versions/commands.py
@@ -38,6 +38,13 @@ def init_workflows_versions_commands(group: Group):
                 help='An optional flag to include deleted workflows in the list',
                 type=bool,
             ),
+            ArgumentSpec(
+                name='label',
+                arg_names=['--label'],
+                help='Filter by label. This flag can be repeated to filter by multiple labels (e.g., --label tag1 --label tag2). '
+                     'A version is included if the label appears on the version itself or any of its transformations.',
+                multiple=True,
+            ),
             CONTEXT_ARG,
             SINGLE_ENDPOINT_ID_ARG,
         ]
@@ -47,6 +54,7 @@ def init_workflows_versions_commands(group: Group):
                       namespace: Optional[str],
                       workflow: str,
                       max_results: Optional[int],
+                      label: List[str] = (),
                       include_deleted: Optional[bool] = False):
         """
         List the available versions for the given workflow
@@ -55,7 +63,8 @@ def init_workflows_versions_commands(group: Group):
         """
         workflows_client = get_workflow_client(context, endpoint_id, namespace)
         list_options = WorkflowVersionListOptions(
-            deleted=include_deleted
+            deleted=include_deleted,
+            label=list(label) if label else None,
         )
         show_iterator(output_format=OutputFormat.JSON,
                       iterator=workflows_client.list_workflow_versions(workflow_id=workflow,

--- a/dnastack/client/workbench/workflow/models.py
+++ b/dnastack/client/workbench/workflow/models.py
@@ -28,6 +28,7 @@ class WorkflowVersion(BaseModel):
     description: Optional[str] = None
     deleted: Optional[bool] = None
     etag: Optional[str] = None
+    labels: Optional[List[str]] = None
 
 
 class Workflow(BaseModel):
@@ -90,6 +91,7 @@ class WorkflowListOptions(BaseListOptions):
     sort: Optional[str] = None
     order: Optional[str] = Field(default=None, deprecated=True)
     direction: Optional[str] = None
+    label: Optional[List[str]] = None
 
 
 class WorkflowListResponse(PaginatedResource):
@@ -101,6 +103,7 @@ class WorkflowListResponse(PaginatedResource):
 
 class WorkflowVersionListOptions(BaseListOptions):
     deleted: Optional[bool] = None
+    label: Optional[List[str]] = None
 
 
 class WorkflowVersionListResponse(PaginatedResource):

--- a/tests/unit/cli/workbench/test_workflows_commands.py
+++ b/tests/unit/cli/workbench/test_workflows_commands.py
@@ -1,0 +1,110 @@
+"""Unit tests for workbench workflows and versions list commands.
+
+Covers [CU-86b5yw7nc]: --label filter flag on workflows list and versions list.
+"""
+import unittest
+from unittest.mock import Mock, patch
+from click.testing import CliRunner
+from click import Group
+
+from dnastack.cli.commands.workbench.workflows.commands import init_workflows_commands
+from dnastack.cli.commands.workbench.workflows.versions.commands import init_workflows_versions_commands
+from dnastack.client.workbench.workflow.models import WorkflowListOptions, WorkflowVersionListOptions
+
+
+class TestWorkflowsListCommand(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.mock_client = Mock()
+        self.mock_client.list_workflows.return_value = iter([])
+        self.group = Group()
+        init_workflows_commands(self.group)
+
+    @patch('dnastack.cli.commands.workbench.workflows.commands.get_workflow_client')
+    def test_list_with_single_label_filter(self, mock_get_client):
+        mock_get_client.return_value = self.mock_client
+
+        result = self.runner.invoke(self.group, ['list', '--label', 'genomics'])
+
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.mock_client.list_workflows.call_args.kwargs
+        self.assertIsInstance(call_kwargs['list_options'], WorkflowListOptions)
+        self.assertEqual(call_kwargs['list_options'].label, ['genomics'])
+
+    @patch('dnastack.cli.commands.workbench.workflows.commands.get_workflow_client')
+    def test_list_with_multiple_label_filters(self, mock_get_client):
+        mock_get_client.return_value = self.mock_client
+
+        result = self.runner.invoke(self.group, ['list', '--label', 'genomics', '--label', 'wgs'])
+
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.mock_client.list_workflows.call_args.kwargs
+        self.assertEqual(call_kwargs['list_options'].label, ['genomics', 'wgs'])
+
+    @patch('dnastack.cli.commands.workbench.workflows.commands.get_workflow_client')
+    def test_list_without_label_filter_sends_none(self, mock_get_client):
+        mock_get_client.return_value = self.mock_client
+
+        result = self.runner.invoke(self.group, ['list'])
+
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.mock_client.list_workflows.call_args.kwargs
+        self.assertIsNone(call_kwargs['list_options'].label)
+
+    @patch('dnastack.cli.commands.workbench.workflows.commands.get_workflow_client')
+    def test_list_label_filter_combined_with_search(self, mock_get_client):
+        mock_get_client.return_value = self.mock_client
+
+        result = self.runner.invoke(self.group, ['list', '--label', 'wgs', '--search', 'align'])
+
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.mock_client.list_workflows.call_args.kwargs
+        opts = call_kwargs['list_options']
+        self.assertEqual(opts.label, ['wgs'])
+        self.assertEqual(opts.search, 'align')
+
+
+class TestWorkflowVersionsListCommand(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.mock_client = Mock()
+        self.mock_client.list_workflow_versions.return_value = iter([])
+        self.group = Group()
+        init_workflows_versions_commands(self.group)
+
+    @patch('dnastack.cli.commands.workbench.workflows.versions.commands.get_workflow_client')
+    def test_list_with_single_label_filter(self, mock_get_client):
+        mock_get_client.return_value = self.mock_client
+
+        result = self.runner.invoke(self.group, ['list', '--workflow', 'wf-123', '--label', 'stable'])
+
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.mock_client.list_workflow_versions.call_args.kwargs
+        self.assertIsInstance(call_kwargs['list_options'], WorkflowVersionListOptions)
+        self.assertEqual(call_kwargs['list_options'].label, ['stable'])
+
+    @patch('dnastack.cli.commands.workbench.workflows.versions.commands.get_workflow_client')
+    def test_list_with_multiple_label_filters(self, mock_get_client):
+        mock_get_client.return_value = self.mock_client
+
+        result = self.runner.invoke(self.group, ['list', '--workflow', 'wf-123', '--label', 'stable', '--label', 'v2'])
+
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.mock_client.list_workflow_versions.call_args.kwargs
+        self.assertEqual(call_kwargs['list_options'].label, ['stable', 'v2'])
+
+    @patch('dnastack.cli.commands.workbench.workflows.versions.commands.get_workflow_client')
+    def test_list_without_label_filter_sends_none(self, mock_get_client):
+        mock_get_client.return_value = self.mock_client
+
+        result = self.runner.invoke(self.group, ['list', '--workflow', 'wf-123'])
+
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.mock_client.list_workflow_versions.call_args.kwargs
+        self.assertIsNone(call_kwargs['list_options'].label)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/client/workbench/workflow/test_workflow_label_filter.py
+++ b/tests/unit/client/workbench/workflow/test_workflow_label_filter.py
@@ -1,0 +1,173 @@
+"""Tests for label filtering on workflow and version list commands.
+
+Covers [CU-86b5yw7nc]: Allow filtering workflows by labels from the CLI.
+"""
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from dnastack.cli.commands.workbench.workflows import workflows_command_group
+from dnastack.client.workbench.workflow.models import (
+    WorkflowListOptions,
+    WorkflowVersion,
+    WorkflowVersionListOptions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+class TestWorkflowListOptionsLabelFilter:
+    def test_accepts_single_label(self):
+        opts = WorkflowListOptions(label=['genomics'])
+        assert opts.label == ['genomics']
+
+    def test_accepts_multiple_labels(self):
+        opts = WorkflowListOptions(label=['genomics', 'wgs'])
+        assert opts.label == ['genomics', 'wgs']
+
+    def test_label_excluded_when_none(self):
+        opts = WorkflowListOptions()
+        dumped = opts.model_dump(exclude_none=True)
+        assert 'label' not in dumped
+
+    def test_label_included_in_serialized_params(self):
+        opts = WorkflowListOptions(label=['genomics', 'wgs'])
+        dumped = opts.model_dump(exclude_none=True)
+        assert dumped['label'] == ['genomics', 'wgs']
+
+
+class TestWorkflowVersionListOptionsLabelFilter:
+    def test_accepts_single_label(self):
+        opts = WorkflowVersionListOptions(label=['v2'])
+        assert opts.label == ['v2']
+
+    def test_accepts_multiple_labels(self):
+        opts = WorkflowVersionListOptions(label=['v2', 'stable'])
+        assert opts.label == ['v2', 'stable']
+
+    def test_label_excluded_when_none(self):
+        opts = WorkflowVersionListOptions()
+        dumped = opts.model_dump(exclude_none=True)
+        assert 'label' not in dumped
+
+    def test_label_included_in_serialized_params(self):
+        opts = WorkflowVersionListOptions(label=['v2', 'stable'])
+        dumped = opts.model_dump(exclude_none=True)
+        assert dumped['label'] == ['v2', 'stable']
+
+
+class TestWorkflowVersionLabelsField:
+    def test_workflow_version_accepts_labels(self):
+        version = WorkflowVersion(
+            id='v1',
+            versionName='1.0',
+            workflowName='my-workflow',
+            descriptorType='WDL',
+            labels=['stable', 'production'],
+        )
+        assert version.labels == ['stable', 'production']
+
+    def test_workflow_version_labels_defaults_to_none(self):
+        version = WorkflowVersion(
+            id='v1',
+            versionName='1.0',
+            workflowName='my-workflow',
+            descriptorType='WDL',
+        )
+        assert version.labels is None
+
+
+# ---------------------------------------------------------------------------
+# CLI command tests
+# ---------------------------------------------------------------------------
+
+def _make_mock_client(workflows=None, versions=None):
+    client = Mock()
+    client.list_workflows.return_value = iter(workflows or [])
+    client.list_workflow_versions.return_value = iter(versions or [])
+    return client
+
+
+@patch('dnastack.cli.commands.workbench.workflows.commands.get_workflow_client')
+class TestListWorkflowsLabelFlag:
+    def test_single_label_passed_to_list_options(self, mock_get_client):
+        mock_client = _make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        runner = CliRunner()
+        result = runner.invoke(workflows_command_group, ['list', '--label', 'genomics'])
+
+        assert result.exit_code == 0, result.output
+        mock_client.list_workflows.assert_called_once()
+        list_options = mock_client.list_workflows.call_args.kwargs['list_options']
+        assert list_options.label == ['genomics']
+
+    def test_multiple_labels_passed_to_list_options(self, mock_get_client):
+        mock_client = _make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        runner = CliRunner()
+        result = runner.invoke(workflows_command_group, [
+            'list', '--label', 'genomics', '--label', 'wgs'
+        ])
+
+        assert result.exit_code == 0, result.output
+        list_options = mock_client.list_workflows.call_args.kwargs['list_options']
+        assert list_options.label == ['genomics', 'wgs']
+
+    def test_no_label_flag_sends_none(self, mock_get_client):
+        mock_client = _make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        runner = CliRunner()
+        result = runner.invoke(workflows_command_group, ['list'])
+
+        assert result.exit_code == 0, result.output
+        list_options = mock_client.list_workflows.call_args.kwargs['list_options']
+        assert list_options.label is None
+
+
+@patch('dnastack.cli.commands.workbench.workflows.versions.commands.get_workflow_client')
+class TestListVersionsLabelFlag:
+    def test_single_label_passed_to_list_options(self, mock_get_client):
+        mock_client = _make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        runner = CliRunner()
+        result = runner.invoke(workflows_command_group, [
+            'versions', 'list', '--workflow', 'wf-123', '--label', 'stable'
+        ])
+
+        assert result.exit_code == 0, result.output
+        mock_client.list_workflow_versions.assert_called_once()
+        list_options = mock_client.list_workflow_versions.call_args.kwargs['list_options']
+        assert list_options.label == ['stable']
+
+    def test_multiple_labels_passed_to_list_options(self, mock_get_client):
+        mock_client = _make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        runner = CliRunner()
+        result = runner.invoke(workflows_command_group, [
+            'versions', 'list', '--workflow', 'wf-123',
+            '--label', 'stable', '--label', 'v2'
+        ])
+
+        assert result.exit_code == 0, result.output
+        list_options = mock_client.list_workflow_versions.call_args.kwargs['list_options']
+        assert list_options.label == ['stable', 'v2']
+
+    def test_no_label_flag_sends_none(self, mock_get_client):
+        mock_client = _make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        runner = CliRunner()
+        result = runner.invoke(workflows_command_group, [
+            'versions', 'list', '--workflow', 'wf-123'
+        ])
+
+        assert result.exit_code == 0, result.output
+        list_options = mock_client.list_workflow_versions.call_args.kwargs['list_options']
+        assert list_options.label is None


### PR DESCRIPTION
## Summary

- Adds a repeatable `--label` flag to `omics workbench workflows list` and `omics workbench workflows versions list`
- Passes labels to the backend as a list; backend matches transitively (workflow, version, or transformation level)
- Help text documents the transitive matching behavior so users understand why a result with `labels: []` may appear
- Adds `label` field to `WorkflowListOptions` and `WorkflowVersionListOptions` models

## Transitive matching

The backend SQL matches a workflow if the label appears on:
1. The workflow itself
2. Any of its versions
3. Any of its transformations

Similarly for version listing: a version matches if the label appears on the version itself or any of its transformations.

A workflow returned with `labels: []` matched via a version or transformation — this is documented in the `--label` flag help text. A follow-up ticket tracks adding a `matched_via` field to the API response for clearer match context.

## Test plan

- [x] `tests/unit/cli/workbench/test_workflows_commands.py` — 7 tests: single label, multiple labels, no-label-sends-none for both command groups
- [x] `tests/unit/client/workbench/workflow/test_workflow_label_filter.py` — 16 tests: model fields and full CLI invocation via `CliRunner`
- [x] Lint clean (`ruff check`)
- [x] Full unit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)