### PR TITLE
[CU-86b46744d] Add --engine/--provider/--region filter flags to defaults list and defaults search subcommand

### DIFF
--- a/dnastack/cli/commands/workbench/workflows/versions/defaults.py
+++ b/dnastack/cli/commands/workbench/workflows/versions/defaults.py
@@ -114,6 +114,21 @@ def create_workflow_defaults(context: Optional[str],
             help='The id of the workflow version',
             required=True,
         ),
+        ArgumentSpec(
+            name='engine',
+            arg_names=['--engine'],
+            help='Filter by engine selector value. Case-insensitive.',
+        ),
+        ArgumentSpec(
+            name='provider',
+            arg_names=['--provider'],
+            help='Filter by provider selector value (e.g. GCP, AWS). Case-insensitive.',
+        ),
+        ArgumentSpec(
+            name='region',
+            arg_names=['--region'],
+            help='Filter by region selector value (e.g. us-central1). Case-insensitive.',
+        ),
         NAMESPACE_ARG,
         MAX_RESULTS_ARG,
         PAGINATION_PAGE_ARG,
@@ -131,19 +146,91 @@ def list_workflow_defaults(context: Optional[str],
                            page_size: Optional[int],
                            sort: Optional[str],
                            workflow_id: str,
-                           version_id: str):
+                           version_id: str,
+                           engine: Optional[str] = None,
+                           provider: Optional[str] = None,
+                           region: Optional[str] = None):
     """
     List the defaults available for a workflow
     """
     client = get_workflow_client(context_name=context, endpoint_id=endpoint_id, namespace=namespace)
 
     show_iterator(output_format=OutputFormat.JSON,
-                  iterator=
-                  client.list_workflow_defaults(workflow_id=workflow_id, version_id=version_id,
-                                                      max_results=max_results,
-                                                      list_options=WorkflowDefaultsListOptions(page=page,
-                                                                                               page_size=page_size,
-                                                                                               sort=sort)))
+                  iterator=client.list_workflow_defaults(
+                      workflow_id=workflow_id,
+                      version_id=version_id,
+                      max_results=max_results,
+                      list_options=WorkflowDefaultsListOptions(
+                          page=page,
+                          page_size=page_size,
+                          sort=sort,
+                          engine=engine,
+                          provider=provider,
+                          region=region,
+                      )))
+
+
+@formatted_command(
+    group=workflows_versions_defaults_command_group,
+    name='search',
+    specs=[
+        ArgumentSpec(
+            name='workflow_id',
+            arg_names=['--workflow'],
+            help='The id of the workflow',
+            required=True,
+        ),
+        ArgumentSpec(
+            name='version_id',
+            arg_names=['--version'],
+            help='The id of the workflow version',
+            required=True,
+        ),
+        ArgumentSpec(
+            name='engine',
+            arg_names=['--engine'],
+            help='Engine selector value to match exactly.',
+        ),
+        ArgumentSpec(
+            name='provider',
+            arg_names=['--provider'],
+            help='Provider selector value to match exactly (e.g. GCP, AWS).',
+        ),
+        ArgumentSpec(
+            name='region',
+            arg_names=['--region'],
+            help='Region selector value to match exactly (e.g. us-central1).',
+        ),
+        NAMESPACE_ARG,
+        CONTEXT_ARG,
+        SINGLE_ENDPOINT_ID_ARG,
+    ]
+)
+def search_workflow_defaults(context: Optional[str],
+                              endpoint_id: Optional[str],
+                              namespace: Optional[str],
+                              workflow_id: str,
+                              version_id: str,
+                              engine: Optional[str] = None,
+                              provider: Optional[str] = None,
+                              region: Optional[str] = None):
+    """
+    Search for a workflow default by exact selector match.
+    Returns the default whose selector exactly matches the provided engine, provider, and region values.
+    Omitted flags match null selector fields.
+    """
+    client = get_workflow_client(context_name=context, endpoint_id=endpoint_id, namespace=namespace)
+    result = client.search_workflow_defaults(
+        workflow_id=workflow_id,
+        version_id=version_id,
+        engine=engine,
+        provider=provider,
+        region=region,
+    )
+    if result is None:
+        click.echo('No default found for the specified selector.', err=True)
+        raise SystemExit(1)
+    click.echo(to_json(normalize(result)))
 
 
 @formatted_command(

--- a/dnastack/client/workbench/workflow/client.py
+++ b/dnastack/client/workbench/workflow/client.py
@@ -15,7 +15,7 @@ from dnastack.client.workbench.workflow.models import WorkflowDescriptor, Workfl
     WorkflowDefaultsCreateRequest, WorkflowDependency, WorkflowDependencyListResponse, WorkflowDependencyListOptions, \
     WorkflowDependencyCreateRequest, WorkflowDependencyUpdateRequest
 from dnastack.common.tracing import Span
-from dnastack.http.session import JsonPatch, HttpSession
+from dnastack.http.session import JsonPatch, HttpSession, ClientError
 
 
 class WorkflowDefaultsListResultLoader(WorkbenchResultLoader):
@@ -335,6 +335,24 @@ class WorkflowClient(BaseWorkbenchClient):
             list_options=list_options,
             trace=None,
             max_results=max_results))
+
+    def search_workflow_defaults(self, workflow_id: str, version_id: str,
+                                engine: Optional[str] = None,
+                                provider: Optional[str] = None,
+                                region: Optional[str] = None) -> Optional[WorkflowDefaults]:
+        params = {k: v for k, v in {'engine': engine, 'provider': provider, 'region': region}.items() if v is not None}
+        with self.create_http_session() as session:
+            try:
+                response = session.get(
+                    urljoin(self.endpoint.url,
+                            f'{self.namespace}/workflows/{workflow_id}/versions/{version_id}/defaults/search'),
+                    params=params
+                )
+                return WorkflowDefaults(**response.json())
+            except ClientError as e:
+                if e.response.status_code == 404:
+                    return None
+                raise
 
     def get_workflow_defaults(self, workflow_id: str, version_id: str, default_id: str) -> WorkflowDefaults:
         with self.create_http_session() as session:

--- a/dnastack/client/workbench/workflow/models.py
+++ b/dnastack/client/workbench/workflow/models.py
@@ -164,6 +164,9 @@ class WorkflowDefaultsListResponse(PaginatedResource):
 
 class WorkflowDefaultsListOptions(BaseListOptions):
     sort: Optional[str] = None
+    engine: Optional[str] = None
+    provider: Optional[str] = None
+    region: Optional[str] = None
 
 
 class WorkflowTransformationCreate(BaseModel):

--- a/tests/unit/cli/workbench/test_workflow_defaults_commands.py
+++ b/tests/unit/cli/workbench/test_workflow_defaults_commands.py
@@ -1,0 +1,107 @@
+"""Unit tests for workflow version defaults CLI commands.
+
+Covers [CU-86b46744d]: Add selector filter to defaults list and search commands.
+"""
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from dnastack.cli.commands.workbench.workflows import workflows_command_group
+from dnastack.client.workbench.workflow.models import WorkflowDefaultsListOptions, WorkflowDefaults
+
+
+def _make_mock_client(defaults=None, search_result=None):
+    client = Mock()
+    client.list_workflow_defaults.return_value = iter(defaults or [])
+    client.search_workflow_defaults.return_value = search_result
+    return client
+
+
+REQUIRED_ARGS = ['versions', 'defaults', 'list', '--workflow', 'wf-123', '--version', 'v-456']
+SEARCH_REQUIRED_ARGS = ['versions', 'defaults', 'search', '--workflow', 'wf-123', '--version', 'v-456']
+
+
+@patch('dnastack.cli.commands.workbench.workflows.versions.defaults.get_workflow_client')
+class TestDefaultsListFilterFlags:
+
+    def test_provider_filter_passed_to_list_options(self, mock_get_client):
+        mock_get_client.return_value = _make_mock_client()
+        result = CliRunner().invoke(workflows_command_group, REQUIRED_ARGS + ['--provider', 'GCP'])
+        assert result.exit_code == 0, result.output
+        opts = mock_get_client.return_value.list_workflow_defaults.call_args.kwargs['list_options']
+        assert opts.provider == 'GCP'
+
+    def test_region_filter_passed_to_list_options(self, mock_get_client):
+        mock_get_client.return_value = _make_mock_client()
+        result = CliRunner().invoke(workflows_command_group, REQUIRED_ARGS + ['--region', 'us-central1'])
+        assert result.exit_code == 0, result.output
+        opts = mock_get_client.return_value.list_workflow_defaults.call_args.kwargs['list_options']
+        assert opts.region == 'us-central1'
+
+    def test_engine_filter_passed_to_list_options(self, mock_get_client):
+        mock_get_client.return_value = _make_mock_client()
+        result = CliRunner().invoke(workflows_command_group, REQUIRED_ARGS + ['--engine', 'cromwell'])
+        assert result.exit_code == 0, result.output
+        opts = mock_get_client.return_value.list_workflow_defaults.call_args.kwargs['list_options']
+        assert opts.engine == 'cromwell'
+
+    def test_all_three_filters_combined(self, mock_get_client):
+        mock_get_client.return_value = _make_mock_client()
+        result = CliRunner().invoke(workflows_command_group,
+            REQUIRED_ARGS + ['--provider', 'GCP', '--region', 'us-central1', '--engine', 'cromwell'])
+        assert result.exit_code == 0, result.output
+        opts = mock_get_client.return_value.list_workflow_defaults.call_args.kwargs['list_options']
+        assert opts.provider == 'GCP'
+        assert opts.region == 'us-central1'
+        assert opts.engine == 'cromwell'
+
+    def test_no_filters_sends_none(self, mock_get_client):
+        mock_get_client.return_value = _make_mock_client()
+        result = CliRunner().invoke(workflows_command_group, REQUIRED_ARGS)
+        assert result.exit_code == 0, result.output
+        opts = mock_get_client.return_value.list_workflow_defaults.call_args.kwargs['list_options']
+        assert opts.provider is None
+        assert opts.region is None
+        assert opts.engine is None
+
+    def test_filters_excluded_from_serialization_when_none(self, mock_get_client):
+        mock_get_client.return_value = _make_mock_client()
+        opts = WorkflowDefaultsListOptions()
+        dumped = opts.model_dump(exclude_none=True)
+        assert 'provider' not in dumped
+        assert 'region' not in dumped
+        assert 'engine' not in dumped
+
+    def test_filters_included_in_serialization_when_set(self, mock_get_client):
+        mock_get_client.return_value = _make_mock_client()
+        opts = WorkflowDefaultsListOptions(provider='GCP', region='us-central1')
+        dumped = opts.model_dump(exclude_none=True)
+        assert dumped['provider'] == 'GCP'
+        assert dumped['region'] == 'us-central1'
+        assert 'engine' not in dumped
+
+
+@patch('dnastack.cli.commands.workbench.workflows.versions.defaults.get_workflow_client')
+class TestDefaultsSearchCommand:
+
+    def test_search_with_provider_and_region(self, mock_get_client):
+        mock_default = WorkflowDefaults(id='d1', name='test')
+        mock_get_client.return_value = _make_mock_client(search_result=mock_default)
+        result = CliRunner().invoke(workflows_command_group,
+            SEARCH_REQUIRED_ARGS + ['--provider', 'GCP', '--region', 'us-central1'])
+        assert result.exit_code == 0, result.output
+        mock_get_client.return_value.search_workflow_defaults.assert_called_once_with(
+            workflow_id='wf-123', version_id='v-456', engine=None, provider='GCP', region='us-central1')
+
+    def test_search_returns_not_found_exit_code_1(self, mock_get_client):
+        mock_get_client.return_value = _make_mock_client(search_result=None)
+        result = CliRunner().invoke(workflows_command_group, SEARCH_REQUIRED_ARGS + ['--provider', 'GCP'])
+        assert result.exit_code == 1
+
+    def test_search_with_no_filters_calls_client(self, mock_get_client):
+        mock_default = WorkflowDefaults(id='catch-all', name='catch-all')
+        mock_get_client.return_value = _make_mock_client(search_result=mock_default)
+        result = CliRunner().invoke(workflows_command_group, SEARCH_REQUIRED_ARGS)
+        assert result.exit_code == 0, result.output
+        mock_get_client.return_value.search_workflow_defaults.assert_called_once_with(
+            workflow_id='wf-123', version_id='v-456', engine=None, provider=None, region=None)


### PR DESCRIPTION
## What

Adds `--engine`, `--provider`, and `--region` filter flags to `omics workbench workflows versions defaults list`, and adds a new `defaults search` subcommand for exact-selector lookup.

## Why

Mirrors backend selector filtering (added in workflow-service PR for CU-86b46744d). Lets users filter the defaults list from the CLI without having to parse the full list output.

## Changes

### `models.py`
- `WorkflowDefaultsListOptions`: 3 new optional fields (`engine`, `provider`, `region`) — serialized as query params via `model_dump(exclude_none=True)`

### `client.py`
- New `search_workflow_defaults(workflow_id, version_id, engine, provider, region)` method
- Returns `Optional[WorkflowDefaults]`; maps 404 → `None`

### `defaults.py` (CLI)
- `list`: 3 new `ArgumentSpec` entries (`--engine`, `--provider`, `--region`); passed into `WorkflowDefaultsListOptions`
- New `search` subcommand: calls `client.search_workflow_defaults`, exits 1 with message if no match

### Tests
- `tests/unit/cli/workbench/test_workflow_defaults_commands.py`: 10 new unit tests (7 for list filters, 3 for search)

## Notes
- This branch also contains commit `f0caab4` (`[CU-86b5yw7nc] Add --label filter flag to workflows list and versions list`) which will be split into a separate PR. That commit is unrelated to the defaults selector work in this PR.