### PR TITLE
[CU-86bafcbka] Allow omics dc query to read SQL from a file

### DIFF
--- a/dnastack/cli/commands/dataconnect/commands.py
+++ b/dnastack/cli/commands/dataconnect/commands.py
@@ -17,7 +17,7 @@ def init_data_connect_commands(group: Group):
             ArgumentSpec(
                 name='query',
                 arg_type=ArgumentType.POSITIONAL,
-                help='The query.',
+                help='The SQL query, or @path/to/query.sql to read from a file.',
                 required=True,
             ),
             ArgumentSpec(
@@ -47,4 +47,5 @@ def init_data_connect_commands(group: Group):
                             decimal_as=decimal_as,
                             no_auth=no_auth,
                             output_format=output,
+                            allow_using_query_from_file=True,
                             trace=trace)

--- a/tests/cli/commands/dataconnect/test_handle_query.py
+++ b/tests/cli/commands/dataconnect/test_handle_query.py
@@ -1,0 +1,41 @@
+import tempfile
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dnastack.cli.commands.dataconnect.utils import handle_query
+
+
+class TestHandleQueryFileInput:
+
+    def _make_client(self):
+        client = Mock()
+        client.query.return_value = iter([])
+        return client
+
+    def test_inline_query_passed_through(self):
+        client = self._make_client()
+        with patch('dnastack.cli.commands.dataconnect.utils.show_iterator'):
+            handle_query(client, 'SELECT 1', allow_using_query_from_file=True)
+        client.query.assert_called_once_with('SELECT 1', no_auth=False, trace=None)
+
+    def test_at_file_syntax_reads_file_contents(self):
+        client = self._make_client()
+        sql = 'SELECT * FROM my_table WHERE id = 1'
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.sql', delete=False) as f:
+            f.write(sql)
+            f.flush()
+            with patch('dnastack.cli.commands.dataconnect.utils.show_iterator'):
+                handle_query(client, f'@{f.name}', allow_using_query_from_file=True)
+        client.query.assert_called_once_with(sql, no_auth=False, trace=None)
+
+    def test_at_file_syntax_raises_on_missing_file(self):
+        client = self._make_client()
+        with pytest.raises(IOError, match='File not found'):
+            handle_query(client, '@/nonexistent/query.sql', allow_using_query_from_file=True)
+
+    def test_at_file_syntax_ignored_when_flag_disabled(self):
+        client = self._make_client()
+        with patch('dnastack.cli.commands.dataconnect.utils.show_iterator'):
+            handle_query(client, '@some_file.sql', allow_using_query_from_file=False)
+        client.query.assert_called_once_with('@some_file.sql', no_auth=False, trace=None)


### PR DESCRIPTION
Enables the existing @file.sql syntax for the dc query command by
passing allow_using_query_from_file=True. Also updates the help text
and adds unit tests covering the file-read, missing-file, and
flag-disabled cases.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
