### PR TITLE
[CU-86baju3x7] CLI: send X-Global-Namespace (with X-Admin-Only-Action) for global workflow ops

### DIFF
--- a/dnastack/client/workbench/workflow/client.py
+++ b/dnastack/client/workbench/workflow/client.py
@@ -17,6 +17,8 @@ from dnastack.client.workbench.workflow.models import WorkflowDescriptor, Workfl
 from dnastack.common.tracing import Span
 from dnastack.http.session import JsonPatch, HttpSession, ClientError
 
+_GLOBAL_NAMESPACE_HEADERS = {'X-Global-Namespace': 'true', 'X-Admin-Only-Action': 'true'}
+
 
 class WorkflowDefaultsListResultLoader(WorkbenchResultLoader):
     def __init__(self,
@@ -216,7 +218,7 @@ class WorkflowClient(BaseWorkbenchClient):
                         admin_only_action: bool = False) -> Workflow:
         headers = {}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             data = {
                 'name': (None, workflow_create_request.name),
@@ -239,7 +241,7 @@ class WorkflowClient(BaseWorkbenchClient):
                        admin_only_action: bool = False) -> WorkflowVersion:
         headers = {}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             data = {
                 'version_name': (None, workflow_version_create_request.version_name),
@@ -256,7 +258,7 @@ class WorkflowClient(BaseWorkbenchClient):
     def delete_workflow(self, workflow_id: str, etag: str, admin_only_action: bool = False):
         headers = {'If-Match': etag}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             session.delete(
                 urljoin(self.endpoint.url, f'{self.namespace}/workflows/{workflow_id}'),
@@ -267,7 +269,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                admin_only_action: bool = False):
         headers = {'If-Match': etag}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             session.delete(
                 urljoin(self.endpoint.url, f'{self.namespace}/workflows/{workflow_id}/versions/{version_id}'),
@@ -278,7 +280,7 @@ class WorkflowClient(BaseWorkbenchClient):
                         admin_only_action: bool = False) -> Workflow:
         headers = {'If-Match': etag}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             updates = [update.model_dump() for update in updates]
             response = session.json_patch(
@@ -293,7 +295,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                 admin_only_action: bool = False) -> WorkflowVersion:
         headers = {'If-Match': etag}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             updates = [update.model_dump() for update in updates]
             response = session.json_patch(
@@ -367,7 +369,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                  admin_only_action: bool = False) -> WorkflowDefaults:
         headers = {}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             response = session.post(
                 urljoin(self.endpoint.url,
@@ -381,7 +383,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                  admin_only_action: bool = False):
         headers = {"If-Match": if_match}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             session.delete(
                 urljoin(self.endpoint.url,
@@ -394,7 +396,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                  admin_only_action: bool = False):
         headers = {"If-Match": if_match}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             response = session.submit("PUT",
                 urljoin(self.endpoint.url,
@@ -427,7 +429,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                        admin_only_action: bool = False):
         headers = {}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             session.delete(
                 urljoin(self.endpoint.url, f'{self.namespace}/workflows/{workflow_id}/versions/{workflow_version_id}/transformations/{transformation_id}'),
@@ -439,7 +441,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                        admin_only_action: bool = False) -> WorkflowTransformation:
         headers = {}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         with self.create_http_session() as session:
             response = session.post(
                 urljoin(self.endpoint.url, f'{self.namespace}/workflows/{workflow_id}/versions/{workflow_version_id}/transformations'),
@@ -472,7 +474,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                    admin_only_action: bool = False) -> WorkflowDependency:
         headers = {}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         
         with self.create_http_session() as session:
             response = session.post(
@@ -487,7 +489,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                    admin_only_action: bool = False) -> WorkflowDependency:
         headers = {}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         
         with self.create_http_session() as session:
             response = session.submit("PUT",
@@ -501,7 +503,7 @@ class WorkflowClient(BaseWorkbenchClient):
                                    admin_only_action: bool = False):
         headers = {}
         if admin_only_action:
-            headers['X-Admin-Only-Action'] = 'true'
+            headers.update(_GLOBAL_NAMESPACE_HEADERS)
         
         with self.create_http_session() as session:
             session.delete(

--- a/tests/cli/test_workbench_workflow_versions.py
+++ b/tests/cli/test_workbench_workflow_versions.py
@@ -1,0 +1,59 @@
+"""`workbench workflows versions create --global` drives the global/admin path (admin_only_action);
+the resulting X-Global-Namespace header is asserted at the client layer in
+tests/unit/client/workbench/workflow/test_workflow_client_admin_header.py."""
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from dnastack.cli.commands.workbench.workflows.versions import workflows_versions_command_group
+from dnastack.client.workbench.workflow.models import WorkflowVersion
+
+_GET_CLIENT = 'dnastack.cli.commands.workbench.workflows.versions.commands.get_workflow_client'
+_EMPTY_ZIP = b'PK\x05\x06' + b'\x00' * 18
+
+
+class TestWorkflowVersionCreateGlobalFlag(TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.mock_workflow_client = Mock()
+        self.mock_workflow_client.create_version.return_value = WorkflowVersion(
+            id='v-id',
+            versionName='2.0',
+            workflowName='test-workflow',
+            descriptorType='WDL',
+        )
+
+    def _invoke_create(self, *extra_args):
+        with self.runner.isolated_filesystem():
+            with open('compress_wdl_files.zip', 'wb') as zip_file:
+                zip_file.write(_EMPTY_ZIP)
+            return self.runner.invoke(workflows_versions_command_group, [
+                'create',
+                '--workflow', 'workflow-1',
+                '--name', '2.0',
+                '--entrypoint', 'main.wdl',
+                *extra_args,
+                'compress_wdl_files.zip',
+            ])
+
+    @patch(_GET_CLIENT)
+    def test_create_version_with_global_flag_is_admin_only_action(self, mock_get_client):
+        mock_get_client.return_value = self.mock_workflow_client
+
+        result = self._invoke_create('--global')
+
+        self.assertEqual(result.exit_code, 0, msg=f"{result.output}\n{result.exception}")
+        self.mock_workflow_client.create_version.assert_called_once()
+        self.assertTrue(self.mock_workflow_client.create_version.call_args.kwargs['admin_only_action'])
+
+    @patch(_GET_CLIENT)
+    def test_create_version_without_global_flag_is_not_admin_only_action(self, mock_get_client):
+        mock_get_client.return_value = self.mock_workflow_client
+
+        result = self._invoke_create()
+
+        self.assertEqual(result.exit_code, 0, msg=f"{result.output}\n{result.exception}")
+        self.mock_workflow_client.create_version.assert_called_once()
+        self.assertFalse(self.mock_workflow_client.create_version.call_args.kwargs['admin_only_action'])

--- a/tests/unit/client/workbench/workflow/test_workflow_client_admin_header.py
+++ b/tests/unit/client/workbench/workflow/test_workflow_client_admin_header.py
@@ -1,4 +1,4 @@
-"""Tests that WorkflowClient methods inject X-Admin-Only-Action header when admin_only_action=True."""
+"""Tests that WorkflowClient methods inject X-Global-Namespace header when admin_only_action=True."""
 from unittest.mock import MagicMock, patch
 
 from dnastack.client.models import ServiceEndpoint
@@ -61,15 +61,16 @@ def _mock_session(response_json=None):
 
 
 class TestAdminOnlyActionHeader:
-    """Verify that admin_only_action=True adds the X-Admin-Only-Action header."""
+    """Verify that admin_only_action=True adds the X-Global-Namespace header."""
 
     def _assert_header_present(self, call_kwargs):
         headers = call_kwargs.get('headers', {})
-        assert 'X-Admin-Only-Action' in headers, f"Expected X-Admin-Only-Action header, got: {headers}"
-        assert headers['X-Admin-Only-Action'] == 'true'
+        assert headers.get('X-Global-Namespace') == 'true', f"Expected X-Global-Namespace=true, got: {headers}"
+        assert headers.get('X-Admin-Only-Action') == 'true', f"Expected X-Admin-Only-Action=true, got: {headers}"
 
     def _assert_header_absent(self, call_kwargs):
         headers = call_kwargs.get('headers', {})
+        assert 'X-Global-Namespace' not in headers, f"Unexpected X-Global-Namespace header in: {headers}"
         assert 'X-Admin-Only-Action' not in headers, f"Unexpected X-Admin-Only-Action header in: {headers}"
 
     def test_create_workflow_sends_admin_header(self):


### PR DESCRIPTION
Part of the fine-grained RBAC rollout (epic 86b9nzq74). The workbench services renamed the global/cross-namespace workflow header `X-Admin-Only-Action` → `X-Global-Namespace` (a boolean, `true`), and read **both** during the transition. This updates the CLI to the new header.

### Rolled out immediately, not staged
The CLI emits **both** headers via `_GLOBAL_NAMESPACE_HEADERS`, so it is compatible at every server stage:
- pre-reland workflow-service (currently deployed) reads `X-Admin-Only-Action` ✓
- relanded workflow-service reads `X-Global-Namespace` (and reads both) ✓
- Stage-3 workflow-service reads only `X-Global-Namespace`, ignores the legacy one ✓

So there is **no deploy-order dependency** on the server reland, and shipping this is what makes "every client emits `X-Global-Namespace`" true — the precondition for workflow-service dropping its legacy header read at Stage 3.

`X-Global-Namespace`-only was not an option for an immediate release: the deployed alpha/prod workflow-service is still the pre-reland build that reads only `X-Admin-Only-Action`, so `--global` would silently degrade to a namespace write.

### Surface unchanged
The `--global` flag / `admin_only_action` param and the `'true'` value are unchanged (14 global/admin workflow ops in `workflow/client.py`).

### Tests
- `tests/unit/client/workbench/workflow/test_workflow_client_admin_header.py` — asserts both headers are sent when `admin_only_action=True`, neither when not.
- `tests/cli/test_workbench_workflow_versions.py` (new) — `workbench workflows versions create --global` drives `admin_only_action=True` (and the default does not).

### Stage-3 cleanup (follow-up, not this PR)
Drop `'X-Admin-Only-Action'` from `_GLOBAL_NAMESPACE_HEADERS` (one line) + the second assertion in the client test, once every workflow-service environment reads `X-Global-Namespace`. That realises this ticket's "no remaining `X-Admin-Only-Action`" acceptance criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
