### PR TITLE
[CU-86bar2y9c] Use nil UUID (not "global") as the global-namespace placeholder

### DIFF
--- a/dnastack/client/workbench/workflow/client.py
+++ b/dnastack/client/workbench/workflow/client.py
@@ -21,8 +21,9 @@ _GLOBAL_NAMESPACE_HEADERS = {'X-Global-Namespace': 'true', 'X-Admin-Only-Action'
 
 # Placeholder path segment for global (platform-admin) operations. The workflow-service
 # ignores the namespace in the path when the global headers are present, so any non-empty,
-# URL-safe value works; it only keeps the request URL well-formed.
-GLOBAL_NAMESPACE = 'global'
+# URL-safe value works; it only keeps the request URL well-formed. Uses a 36-char nil UUID
+# so it satisfies the api-host ingress route regex ({namespace:[a-zA-Z0-9-]{36,}}).
+GLOBAL_NAMESPACE = '00000000-0000-0000-0000-000000000000'
 
 
 class WorkflowDefaultsListResultLoader(WorkbenchResultLoader):


### PR DESCRIPTION
## Problem
`#179` made `--global` operations send the literal `global` as the path namespace
(`POST /global/workflows/{id}/versions`). But the workbench **api-host ingress** route only matches a
UUID-length namespace — `PathPrefix(/{namespace:[a-zA-Z0-9-]{36,}}/workflows)` — so `global` (6 chars)
is dropped by Traefik with a bare `404 page not found` **before it reaches workflow-service**. Confirmed on the wire:

```
"POST /global/workflows/664e2ea1-.../versions HTTP/1.1" 404 19   # 19-byte "404 page not found"
```

## Fix
Set `GLOBAL_NAMESPACE` to the RFC-4122/9562 **nil UUID** `00000000-0000-0000-0000-000000000000`:
- 36 chars → satisfies the existing `{36,}` ingress regex in **every** environment, so **no ingress/back-end change is required**.
- Still a recognizable sentinel (nil UUID never collides with a generated namespace).
- The value is inert on the server: for admin ops `NamespaceUtil.getEffectiveNamespace(ns, adminOnlyAction)` returns `null`, so workflow-service ignores the path namespace and routes the global write via the `X-Global-Namespace` header. The placeholder only appears in routing / the authz-resource string / `Location` / audit.

Supersedes the `global` placeholder introduced in `#179`. The existing `test_global_namespace_getter` asserts against the `GLOBAL_NAMESPACE` constant (not the literal), so it stays green.

## Note
This makes the workflow-service ingress change (workflow-service#163, which had widened the route to accept `global`) unnecessary — that PR can be reverted. See decision doc for the `global`-vs-nil-UUID rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)