### PR TITLE
[CU-86baqy91f] Remove deprecated X-Admin-Only-Action header (send only X-Global-Namespace)

### DIFF
--- a/dnastack/client/workbench/workflow/client.py
+++ b/dnastack/client/workbench/workflow/client.py
@@ -17,7 +17,7 @@ from dnastack.client.workbench.workflow.models import WorkflowDescriptor, Workfl
 from dnastack.common.tracing import Span
 from dnastack.http.session import JsonPatch, HttpSession, ClientError
 
-_GLOBAL_NAMESPACE_HEADERS = {'X-Global-Namespace': 'true', 'X-Admin-Only-Action': 'true'}
+_GLOBAL_NAMESPACE_HEADERS = {'X-Global-Namespace': 'true'}
 
 
 class WorkflowDefaultsListResultLoader(WorkbenchResultLoader):

--- a/tests/unit/client/workbench/workflow/test_workflow_client_admin_header.py
+++ b/tests/unit/client/workbench/workflow/test_workflow_client_admin_header.py
@@ -66,12 +66,10 @@ class TestAdminOnlyActionHeader:
     def _assert_header_present(self, call_kwargs):
         headers = call_kwargs.get('headers', {})
         assert headers.get('X-Global-Namespace') == 'true', f"Expected X-Global-Namespace=true, got: {headers}"
-        assert headers.get('X-Admin-Only-Action') == 'true', f"Expected X-Admin-Only-Action=true, got: {headers}"
 
     def _assert_header_absent(self, call_kwargs):
         headers = call_kwargs.get('headers', {})
         assert 'X-Global-Namespace' not in headers, f"Unexpected X-Global-Namespace header in: {headers}"
-        assert 'X-Admin-Only-Action' not in headers, f"Unexpected X-Admin-Only-Action header in: {headers}"
 
     def test_create_workflow_sends_admin_header(self):
         client = _create_workflow_client()


### PR DESCRIPTION
## Why
The CLI's dual-header (CU-86baju3x7) sent **both** `X-Global-Namespace` and the legacy `X-Admin-Only-Action` so it worked against workbench services on either side of the header refactor. Fine-grained enforcement is now on everywhere and workflow-service no longer reads the legacy header (Phase 3 — workflow-service #167), so the backward-compat leg is dead. CLI analog of the services' Phase 3. (CU-86baqy91f)

## What
- `workflow/client.py`: `_GLOBAL_NAMESPACE_HEADERS` → `{'X-Global-Namespace': 'true'}` (drop `X-Admin-Only-Action`). The 15 global/admin workflow ops that `.update(_GLOBAL_NAMESPACE_HEADERS)` now send only `X-Global-Namespace`.
- `test_workflow_client_admin_header.py`: drop the dual-header assertion and the legacy-absence assertion.

Zero `X-Admin-Only-Action` references remain in the repo (code + tests).

## Testing
`ruff check` clean; the 13 header unit tests pass. The e2e criterion (a global workflow op against alpha with fine-grained enforcement ON) runs in CI.

**Sequencing:** safe to ship — the prerequisite CU-86baqpzv7 (enforcement enabled everywhere; services ignore the legacy header) is complete.
